### PR TITLE
Remove non-alphanumeric entries

### DIFF
--- a/2014/general/20141104__nh__general__town.csv
+++ b/2014/general/20141104__nh__general__town.csv
@@ -2183,21 +2183,21 @@ Sullivan,Lempster,State House District No. 11,,Scatter,0.0
 Sullivan,Washington,State House District No. 11,R,Smith,292.0
 Sullivan,Washington,State House District No. 11,D,Wooddell,155.0
 Sullivan,Washington,State House District No. 11,,Scatter,0.0
-,Atkinson and Gilmanton Ac. Gt.,State Senate District 1,R,Mark Evans,--
-,Atkinson and Gilmanton Ac. Gt.,State Senate District 1,D,Jeff Woodburn,--
-,Atkinson and Gilmanton Ac. Gt.,State Senate District 1,,Scatter,--
+,Atkinson and Gilmanton Ac. Gt.,State Senate District 1,R,Mark Evans,
+,Atkinson and Gilmanton Ac. Gt.,State Senate District 1,D,Jeff Woodburn,
+,Atkinson and Gilmanton Ac. Gt.,State Senate District 1,,Scatter,
 ,Bath,State Senate District 1,R,Mark Evans,213.0
 ,Bath,State Senate District 1,D,Jeff Woodburn,191.0
 ,Bath,State Senate District 1,,Scatter,0.0
 ,Benton,State Senate District 1,R,Mark Evans,73.0
 ,Benton,State Senate District 1,D,Jeff Woodburn,49.0
 ,Benton,State Senate District 1,,Scatter,0.0
-,Bean's Grant,State Senate District 1,R,Mark Evans,--
-,Bean's Grant,State Senate District 1,D,Jeff Woodburn,--
-,Bean's Grant,State Senate District 1,,Scatter,--
-,Bean's Purchase,State Senate District 1,R,Mark Evans,--
-,Bean's Purchase,State Senate District 1,D,Jeff Woodburn,--
-,Bean's Purchase,State Senate District 1,,Scatter,--
+,Bean's Grant,State Senate District 1,R,Mark Evans,
+,Bean's Grant,State Senate District 1,D,Jeff Woodburn,
+,Bean's Grant,State Senate District 1,,Scatter,
+,Bean's Purchase,State Senate District 1,R,Mark Evans,
+,Bean's Purchase,State Senate District 1,D,Jeff Woodburn,
+,Bean's Purchase,State Senate District 1,,Scatter,
 ,Berlin,State Senate District 1,R,Mark Evans,809.0
 ,Berlin,State Senate District 1,D,Jeff Woodburn,1834.0
 ,Berlin,State Senate District 1,,Scatter,1.0
@@ -2210,9 +2210,9 @@ Sullivan,Washington,State House District No. 11,,Scatter,0.0
 ,Carroll,State Senate District 1,R,Mark Evans,130.0
 ,Carroll,State Senate District 1,D,Jeff Woodburn,200.0
 ,Carroll,State Senate District 1,,Scatter,0.0
-,Chandler's Purchase,State Senate District 1,R,Mark Evans,--
-,Chandler's Purchase,State Senate District 1,D,Jeff Woodburn,--
-,Chandler's Purchase,State Senate District 1,,Scatter,--
+,Chandler's Purchase,State Senate District 1,R,Mark Evans,
+,Chandler's Purchase,State Senate District 1,D,Jeff Woodburn,
+,Chandler's Purchase,State Senate District 1,,Scatter,
 ,Clarksville,State Senate District 1,R,Mark Evans,55.0
 ,Clarksville,State Senate District 1,D,Jeff Woodburn,54.0
 ,Clarksville,State Senate District 1,,Scatter,0.0
@@ -2222,18 +2222,18 @@ Sullivan,Washington,State House District No. 11,,Scatter,0.0
 ,Columbia,State Senate District 1,R,Mark Evans,102.0
 ,Columbia,State Senate District 1,D,Jeff Woodburn,133.0
 ,Columbia,State Senate District 1,,Scatter,0.0
-,Crawford's Purchase,State Senate District 1,R,Mark Evans,--
-,Crawford's Purchase,State Senate District 1,D,Jeff Woodburn,--
-,Crawford's Purchase,State Senate District 1,,Scatter,--
-,Cutt's Grant,State Senate District 1,R,Mark Evans,--
-,Cutt's Grant,State Senate District 1,D,Jeff Woodburn,--
-,Cutt's Grant,State Senate District 1,,Scatter,--
+,Crawford's Purchase,State Senate District 1,R,Mark Evans,
+,Crawford's Purchase,State Senate District 1,D,Jeff Woodburn,
+,Crawford's Purchase,State Senate District 1,,Scatter,
+,Cutt's Grant,State Senate District 1,R,Mark Evans,
+,Cutt's Grant,State Senate District 1,D,Jeff Woodburn,
+,Cutt's Grant,State Senate District 1,,Scatter,
 ,Dalton,State Senate District 1,R,Mark Evans,113.0
 ,Dalton,State Senate District 1,D,Jeff Woodburn,215.0
 ,Dalton,State Senate District 1,,Scatter,0.0
-,Dix's Grant,State Senate District 1,R,Mark Evans,--
-,Dix's Grant,State Senate District 1,D,Jeff Woodburn,--
-,Dix's Grant,State Senate District 1,,Scatter,--
+,Dix's Grant,State Senate District 1,R,Mark Evans,
+,Dix's Grant,State Senate District 1,D,Jeff Woodburn,
+,Dix's Grant,State Senate District 1,,Scatter,
 ,Dixville,State Senate District 1,R,Mark Evans,3.0
 ,Dixville,State Senate District 1,D,Jeff Woodburn,2.0
 ,Dixville,State Senate District 1,,Scatter,0.0
@@ -2246,9 +2246,9 @@ Sullivan,Washington,State House District No. 11,,Scatter,0.0
 ,Errol,State Senate District 1,R,Mark Evans,71.0
 ,Errol,State Senate District 1,D,Jeff Woodburn,68.0
 ,Errol,State Senate District 1,,Scatter,0.0
-,Erving's Location,State Senate District 1,R,Mark Evans,--
-,Erving's Location,State Senate District 1,D,Jeff Woodburn,--
-,Erving's Location,State Senate District 1,,Scatter,--
+,Erving's Location,State Senate District 1,R,Mark Evans,
+,Erving's Location,State Senate District 1,D,Jeff Woodburn,
+,Erving's Location,State Senate District 1,,Scatter,
 ,Franconia,State Senate District 1,R,Mark Evans,201.0
 ,Franconia,State Senate District 1,D,Jeff Woodburn,381.0
 ,Franconia,State Senate District 1,,Scatter,0.0
@@ -2258,15 +2258,15 @@ Sullivan,Washington,State House District No. 11,,Scatter,0.0
 ,Green's Grant,State Senate District 1,R,Mark Evans,0.0
 ,Green's Grant,State Senate District 1,D,Jeff Woodburn,1.0
 ,Green's Grant,State Senate District 1,,Scatter,0.0
-,Hadley's Purchase,State Senate District 1,R,Mark Evans,--
-,Hadley's Purchase,State Senate District 1,D,Jeff Woodburn,--
-,Hadley's Purchase,State Senate District 1,,Scatter,--
+,Hadley's Purchase,State Senate District 1,R,Mark Evans,
+,Hadley's Purchase,State Senate District 1,D,Jeff Woodburn,
+,Hadley's Purchase,State Senate District 1,,Scatter,
 ,Jefferson,State Senate District 1,R,Mark Evans,167.0
 ,Jefferson,State Senate District 1,D,Jeff Woodburn,255.0
 ,Jefferson,State Senate District 1,,Scatter,1.0
-,Kilkenny,State Senate District 1,R,Mark Evans,--
-,Kilkenny,State Senate District 1,D,Jeff Woodburn,--
-,Kilkenny,State Senate District 1,,Scatter,--
+,Kilkenny,State Senate District 1,R,Mark Evans,
+,Kilkenny,State Senate District 1,D,Jeff Woodburn,
+,Kilkenny,State Senate District 1,,Scatter,
 ,Lancaster,State Senate District 1,R,Mark Evans,434.0
 ,Lancaster,State Senate District 1,D,Jeff Woodburn,669.0
 ,Lancaster,State Senate District 1,,Scatter,0.0
@@ -2282,18 +2282,18 @@ Sullivan,Washington,State House District No. 11,,Scatter,0.0
 ,Littleton,State Senate District 1,R,Mark Evans,798.0
 ,Littleton,State Senate District 1,D,Jeff Woodburn,1139.0
 ,Littleton,State Senate District 1,,Scatter,1.0
-,Livermore,State Senate District 1,R,Mark Evans,--
-,Livermore,State Senate District 1,D,Jeff Woodburn,--
-,Livermore,State Senate District 1,,Scatter,--
-,Low and Burbank's Grant,State Senate District 1,R,Mark Evans,--
-,Low and Burbank's Grant,State Senate District 1,D,Jeff Woodburn,--
-,Low and Burbank's Grant,State Senate District 1,,Scatter,--
+,Livermore,State Senate District 1,R,Mark Evans,
+,Livermore,State Senate District 1,D,Jeff Woodburn,
+,Livermore,State Senate District 1,,Scatter,
+,Low and Burbank's Grant,State Senate District 1,R,Mark Evans,
+,Low and Burbank's Grant,State Senate District 1,D,Jeff Woodburn,
+,Low and Burbank's Grant,State Senate District 1,,Scatter,
 ,Lyman,State Senate District 1,R,Mark Evans,113.0
 ,Lyman,State Senate District 1,D,Jeff Woodburn,127.0
 ,Lyman,State Senate District 1,,Scatter,0.0
-,Martin's Location,State Senate District 1,R,Mark Evans,--
-,Martin's Location,State Senate District 1,D,Jeff Woodburn,--
-,Martin's Location,State Senate District 1,,Scatter,--
+,Martin's Location,State Senate District 1,R,Mark Evans,
+,Martin's Location,State Senate District 1,D,Jeff Woodburn,
+,Martin's Location,State Senate District 1,,Scatter,
 ,Milan,State Senate District 1,R,Mark Evans,214.0
 ,Milan,State Senate District 1,D,Jeff Woodburn,270.0
 ,Milan,State Senate District 1,,Scatter,0.0
@@ -2306,24 +2306,24 @@ Sullivan,Washington,State House District No. 11,,Scatter,0.0
 ,Northumberland,State Senate District 1,R,Mark Evans,242.0
 ,Northumberland,State Senate District 1,D,Jeff Woodburn,411.0
 ,Northumberland,State Senate District 1,,Scatter,0.0
-,Odell,State Senate District 1,R,Mark Evans,--
-,Odell,State Senate District 1,D,Jeff Woodburn,--
-,Odell,State Senate District 1,,Scatter,--
-,Pinkham's Grant,State Senate District 1,R,Mark Evans,--
-,Pinkham's Grant,State Senate District 1,D,Jeff Woodburn,--
-,Pinkham's Grant,State Senate District 1,,Scatter,--
+,Odell,State Senate District 1,R,Mark Evans,
+,Odell,State Senate District 1,D,Jeff Woodburn,
+,Odell,State Senate District 1,,Scatter,
+,Pinkham's Grant,State Senate District 1,R,Mark Evans,
+,Pinkham's Grant,State Senate District 1,D,Jeff Woodburn,
+,Pinkham's Grant,State Senate District 1,,Scatter,
 ,Pittsburg,State Senate District 1,R,Mark Evans,208.0
 ,Pittsburg,State Senate District 1,D,Jeff Woodburn,159.0
 ,Pittsburg,State Senate District 1,,Scatter,0.0
 ,Randolph,State Senate District 1,R,Mark Evans,43.0
 ,Randolph,State Senate District 1,D,Jeff Woodburn,147.0
 ,Randolph,State Senate District 1,,Scatter,0.0
-,Sargent's Purchase,State Senate District 1,R,Mark Evans,--
-,Sargent's Purchase,State Senate District 1,D,Jeff Woodburn,--
-,Sargent's Purchase,State Senate District 1,,Scatter,--
-,Second College Grant,State Senate District 1,R,Mark Evans,--
-,Second College Grant,State Senate District 1,D,Jeff Woodburn,--
-,Second College Grant,State Senate District 1,,Scatter,--
+,Sargent's Purchase,State Senate District 1,R,Mark Evans,
+,Sargent's Purchase,State Senate District 1,D,Jeff Woodburn,
+,Sargent's Purchase,State Senate District 1,,Scatter,
+,Second College Grant,State Senate District 1,R,Mark Evans,
+,Second College Grant,State Senate District 1,D,Jeff Woodburn,
+,Second College Grant,State Senate District 1,,Scatter,
 ,Shelburne,State Senate District 1,R,Mark Evans,85.0
 ,Shelburne,State Senate District 1,D,Jeff Woodburn,112.0
 ,Shelburne,State Senate District 1,,Scatter,0.0
@@ -2336,15 +2336,15 @@ Sullivan,Washington,State House District No. 11,,Scatter,0.0
 ,Stratford,State Senate District 1,R,Mark Evans,57.0
 ,Stratford,State Senate District 1,D,Jeff Woodburn,131.0
 ,Stratford,State Senate District 1,,Scatter,0.0
-,Success,State Senate District 1,R,Mark Evans,--
-,Success,State Senate District 1,D,Jeff Woodburn,--
-,Success,State Senate District 1,,Scatter,--
+,Success,State Senate District 1,R,Mark Evans,
+,Success,State Senate District 1,D,Jeff Woodburn,
+,Success,State Senate District 1,,Scatter,
 ,Sugar Hill,State Senate District 1,R,Mark Evans,124.0
 ,Sugar Hill,State Senate District 1,D,Jeff Woodburn,191.0
 ,Sugar Hill,State Senate District 1,,Scatter,0.0
-,Thompson & Meserve's Pur.,State Senate District 1,R,Mark Evans,--
-,Thompson & Meserve's Pur.,State Senate District 1,D,Jeff Woodburn,--
-,Thompson & Meserve's Pur.,State Senate District 1,,Scatter,--
+,Thompson & Meserve's Pur.,State Senate District 1,R,Mark Evans,
+,Thompson & Meserve's Pur.,State Senate District 1,D,Jeff Woodburn,
+,Thompson & Meserve's Pur.,State Senate District 1,,Scatter,
 ,Thornton,State Senate District 1,R,Mark Evans,466.0
 ,Thornton,State Senate District 1,D,Jeff Woodburn,487.0
 ,Thornton,State Senate District 1,,Scatter,0.0
@@ -4446,9 +4446,9 @@ Sullivan,Washington,State House District No. 11,,Scatter,0.0
 ,Bath,Congressional District 2,R,Marilinda Garcia,208.0
 ,Bath,Congressional District 2,D,Ann McLane Kuster,203.0
 ,Bath,Congressional District 2,,Scatter,1.0
-,Bean's Grant,Congressional District 2,R,Marilinda Garcia,--
-,Bean's Grant,Congressional District 2,D,Ann McLane Kuster,--
-,Bean's Grant,Congressional District 2,,Scatter,--
+,Bean's Grant,Congressional District 2,R,Marilinda Garcia,
+,Bean's Grant,Congressional District 2,D,Ann McLane Kuster,
+,Bean's Grant,Congressional District 2,,Scatter,
 ,Bean's Purchase,Congressional District 2,R,Marilinda Garcia,0.0
 ,Bean's Purchase,Congressional District 2,D,Ann McLane Kuster,0.0
 ,Bean's Purchase,Congressional District 2,,Scatter,0.0
@@ -4497,9 +4497,9 @@ Sullivan,Washington,State House District No. 11,,Scatter,0.0
 ,Center Harbor,Congressional District 2,R,Marilinda Garcia,284.0
 ,Center Harbor,Congressional District 2,D,Ann McLane Kuster,245.0
 ,Center Harbor,Congressional District 2,,Scatter,1.0
-,Chandler's Purchase,Congressional District 2,R,Marilinda Garcia,--
-,Chandler's Purchase,Congressional District 2,D,Ann McLane Kuster,--
-,Chandler's Purchase,Congressional District 2,,Scatter,--
+,Chandler's Purchase,Congressional District 2,R,Marilinda Garcia,
+,Chandler's Purchase,Congressional District 2,D,Ann McLane Kuster,
+,Chandler's Purchase,Congressional District 2,,Scatter,
 ,Charlestown,Congressional District 2,R,Marilinda Garcia,594.0
 ,Charlestown,Congressional District 2,D,Ann McLane Kuster,821.0
 ,Charlestown,Congressional District 2,,Scatter,4.0
@@ -4560,15 +4560,15 @@ Sullivan,Washington,State House District No. 11,,Scatter,0.0
 ,Cornish,Congressional District 2,R,Marilinda Garcia,304.0
 ,Cornish,Congressional District 2,D,Ann McLane Kuster,463.0
 ,Cornish,Congressional District 2,,Scatter,0.0
-,Crawford's Purchase,Congressional District 2,R,Marilinda Garcia,--
-,Crawford's Purchase,Congressional District 2,D,Ann McLane Kuster,--
-,Crawford's Purchase,Congressional District 2,,Scatter,--
+,Crawford's Purchase,Congressional District 2,R,Marilinda Garcia,
+,Crawford's Purchase,Congressional District 2,D,Ann McLane Kuster,
+,Crawford's Purchase,Congressional District 2,,Scatter,
 ,Croydon,Congressional District 2,R,Marilinda Garcia,183.0
 ,Croydon,Congressional District 2,D,Ann McLane Kuster,118.0
 ,Croydon,Congressional District 2,,Scatter,0.0
-,Cutt's Grant,Congressional District 2,R,Marilinda Garcia,--
-,Cutt's Grant,Congressional District 2,D,Ann McLane Kuster,--
-,Cutt's Grant,Congressional District 2,,Scatter,--
+,Cutt's Grant,Congressional District 2,R,Marilinda Garcia,
+,Cutt's Grant,Congressional District 2,D,Ann McLane Kuster,
+,Cutt's Grant,Congressional District 2,,Scatter,
 ,Dalton,Congressional District 2,R,Marilinda Garcia,166.0
 ,Dalton,Congressional District 2,D,Ann McLane Kuster,156.0
 ,Dalton,Congressional District 2,,Scatter,0.0
@@ -4662,9 +4662,9 @@ Sullivan,Washington,State House District No. 11,,Scatter,0.0
 ,Groton,Congressional District 2,R,Marilinda Garcia,112.0
 ,Groton,Congressional District 2,D,Ann McLane Kuster,99.0
 ,Groton,Congressional District 2,,Scatter,2.0
-,Hadley's Purchase,Congressional District 2,R,Marilinda Garcia,--
-,Hadley's Purchase,Congressional District 2,D,Ann McLane Kuster,--
-,Hadley's Purchase,Congressional District 2,,Scatter,--
+,Hadley's Purchase,Congressional District 2,R,Marilinda Garcia,
+,Hadley's Purchase,Congressional District 2,D,Ann McLane Kuster,
+,Hadley's Purchase,Congressional District 2,,Scatter,
 ,Hancock,Congressional District 2,R,Marilinda Garcia,365.0
 ,Hancock,Congressional District 2,D,Ann McLane Kuster,581.0
 ,Hancock,Congressional District 2,,Scatter,3.0
@@ -4725,9 +4725,9 @@ Sullivan,Washington,State House District No. 11,,Scatter,0.0
 ,Keene - Ward 5,Congressional District 2,R,Marilinda Garcia,660.0
 ,Keene - Ward 5,Congressional District 2,D,Ann McLane Kuster,1151.0
 ,Keene - Ward 5,Congressional District 2,,Scatter,2.0
-,Kilkenny,Congressional District 2,R,Marilinda Garcia,--
-,Kilkenny,Congressional District 2,D,Ann McLane Kuster,--
-,Kilkenny,Congressional District 2,,Scatter,--
+,Kilkenny,Congressional District 2,R,Marilinda Garcia,
+,Kilkenny,Congressional District 2,D,Ann McLane Kuster,
+,Kilkenny,Congressional District 2,,Scatter,
 ,Lancaster,Congressional District 2,R,Marilinda Garcia,516.0
 ,Lancaster,Congressional District 2,D,Ann McLane Kuster,564.0
 ,Lancaster,Congressional District 2,,Scatter,5.0
@@ -4761,15 +4761,15 @@ Sullivan,Washington,State House District No. 11,,Scatter,0.0
 ,Littleton,Congressional District 2,R,Marilinda Garcia,911.0
 ,Littleton,Congressional District 2,D,Ann McLane Kuster,1034.0
 ,Littleton,Congressional District 2,,Scatter,0.0
-,Livermore,Congressional District 2,R,Marilinda Garcia,--
-,Livermore,Congressional District 2,D,Ann McLane Kuster,--
-,Livermore,Congressional District 2,,Scatter,--
+,Livermore,Congressional District 2,R,Marilinda Garcia,
+,Livermore,Congressional District 2,D,Ann McLane Kuster,
+,Livermore,Congressional District 2,,Scatter,
 ,Loudon,Congressional District 2,R,Marilinda Garcia,1103.0
 ,Loudon,Congressional District 2,D,Ann McLane Kuster,986.0
 ,Loudon,Congressional District 2,,Scatter,2.0
-,Low & Burbank's Grant,Congressional District 2,R,Marilinda Garcia,--
-,Low & Burbank's Grant,Congressional District 2,D,Ann McLane Kuster,--
-,Low & Burbank's Grant,Congressional District 2,,Scatter,--
+,Low & Burbank's Grant,Congressional District 2,R,Marilinda Garcia,
+,Low & Burbank's Grant,Congressional District 2,D,Ann McLane Kuster,
+,Low & Burbank's Grant,Congressional District 2,,Scatter,
 ,Lyman,Congressional District 2,R,Marilinda Garcia,116.0
 ,Lyman,Congressional District 2,D,Ann McLane Kuster,125.0
 ,Lyman,Congressional District 2,,Scatter,0.0
@@ -4785,9 +4785,9 @@ Sullivan,Washington,State House District No. 11,,Scatter,0.0
 ,Marlow,Congressional District 2,R,Marilinda Garcia,117.0
 ,Marlow,Congressional District 2,D,Ann McLane Kuster,176.0
 ,Marlow,Congressional District 2,,Scatter,0.0
-,Martin's Location,Congressional District 2,R,Marilinda Garcia,--
-,Martin's Location,Congressional District 2,D,Ann McLane Kuster,--
-,Martin's Location,Congressional District 2,,Scatter,--
+,Martin's Location,Congressional District 2,R,Marilinda Garcia,
+,Martin's Location,Congressional District 2,D,Ann McLane Kuster,
+,Martin's Location,Congressional District 2,,Scatter,
 ,Mason,Congressional District 2,R,Marilinda Garcia,338.0
 ,Mason,Congressional District 2,D,Ann McLane Kuster,249.0
 ,Mason,Congressional District 2,,Scatter,0.0
@@ -4860,9 +4860,9 @@ Sullivan,Washington,State House District No. 11,,Scatter,0.0
 ,Northwood,Congressional District 2,R,Marilinda Garcia,830.0
 ,Northwood,Congressional District 2,D,Ann McLane Kuster,847.0
 ,Northwood,Congressional District 2,,Scatter,7.0
-,Odell,Congressional District 2,R,Marilinda Garcia,--
-,Odell,Congressional District 2,D,Ann McLane Kuster,--
-,Odell,Congressional District 2,,Scatter,--
+,Odell,Congressional District 2,R,Marilinda Garcia,
+,Odell,Congressional District 2,D,Ann McLane Kuster,
+,Odell,Congressional District 2,,Scatter,
 ,Orange,Congressional District 2,R,Marilinda Garcia,53.0
 ,Orange,Congressional District 2,D,Ann McLane Kuster,71.0
 ,Orange,Congressional District 2,,Scatter,0.0
@@ -4881,9 +4881,9 @@ Sullivan,Washington,State House District No. 11,,Scatter,0.0
 ,Piermont,Congressional District 2,R,Marilinda Garcia,116.0
 ,Piermont,Congressional District 2,D,Ann McLane Kuster,176.0
 ,Piermont,Congressional District 2,,Scatter,0.0
-,Pinkham's Grant,Congressional District 2,R,Marilinda Garcia,--
-,Pinkham's Grant,Congressional District 2,D,Ann McLane Kuster,--
-,Pinkham's Grant,Congressional District 2,,Scatter,--
+,Pinkham's Grant,Congressional District 2,R,Marilinda Garcia,
+,Pinkham's Grant,Congressional District 2,D,Ann McLane Kuster,
+,Pinkham's Grant,Congressional District 2,,Scatter,
 ,Pittsburg,Congressional District 2,R,Marilinda Garcia,211.0
 ,Pittsburg,Congressional District 2,D,Ann McLane Kuster,137.0
 ,Pittsburg,Congressional District 2,,Scatter,0.0
@@ -4917,12 +4917,12 @@ Sullivan,Washington,State House District No. 11,,Scatter,0.0
 ,Salisbury,Congressional District 2,R,Marilinda Garcia,287.0
 ,Salisbury,Congressional District 2,D,Ann McLane Kuster,279.0
 ,Salisbury,Congressional District 2,,Scatter,1.0
-,Sargent's Purchase,Congressional District 2,R,Marilinda Garcia,--
-,Sargent's Purchase,Congressional District 2,D,Ann McLane Kuster,--
-,Sargent's Purchase,Congressional District 2,,Scatter,--
-,Second College Grant,Congressional District 2,R,Marilinda Garcia,--
-,Second College Grant,Congressional District 2,D,Ann McLane Kuster,--
-,Second College Grant,Congressional District 2,,Scatter,--
+,Sargent's Purchase,Congressional District 2,R,Marilinda Garcia,
+,Sargent's Purchase,Congressional District 2,D,Ann McLane Kuster,
+,Sargent's Purchase,Congressional District 2,,Scatter,
+,Second College Grant,Congressional District 2,R,Marilinda Garcia,
+,Second College Grant,Congressional District 2,D,Ann McLane Kuster,
+,Second College Grant,Congressional District 2,,Scatter,
 ,Sharon,Congressional District 2,R,Marilinda Garcia,76.0
 ,Sharon,Congressional District 2,D,Ann McLane Kuster,117.0
 ,Sharon,Congressional District 2,,Scatter,0.0
@@ -4944,9 +4944,9 @@ Sullivan,Washington,State House District No. 11,,Scatter,0.0
 ,Stratford,Congressional District 2,R,Marilinda Garcia,67.0
 ,Stratford,Congressional District 2,D,Ann McLane Kuster,118.0
 ,Stratford,Congressional District 2,,Scatter,0.0
-,Success,Congressional District 2,R,Marilinda Garcia,--
-,Success,Congressional District 2,D,Ann McLane Kuster,--
-,Success,Congressional District 2,,Scatter,--
+,Success,Congressional District 2,R,Marilinda Garcia,
+,Success,Congressional District 2,D,Ann McLane Kuster,
+,Success,Congressional District 2,,Scatter,
 ,Sugar Hill,Congressional District 2,R,Marilinda Garcia,126.0
 ,Sugar Hill,Congressional District 2,D,Ann McLane Kuster,194.0
 ,Sugar Hill,Congressional District 2,,Scatter,0.0
@@ -4968,9 +4968,9 @@ Sullivan,Washington,State House District No. 11,,Scatter,0.0
 ,Temple,Congressional District 2,R,Marilinda Garcia,322.0
 ,Temple,Congressional District 2,D,Ann McLane Kuster,344.0
 ,Temple,Congressional District 2,,Scatter,2.0
-,Thomp. and Mes's Pur.,Congressional District 2,R,Marilinda Garcia,--
-,Thomp. and Mes's Pur.,Congressional District 2,D,Ann McLane Kuster,--
-,Thomp. and Mes's Pur.,Congressional District 2,,Scatter,--
+,Thomp. and Mes's Pur.,Congressional District 2,R,Marilinda Garcia,
+,Thomp. and Mes's Pur.,Congressional District 2,D,Ann McLane Kuster,
+,Thomp. and Mes's Pur.,Congressional District 2,,Scatter,
 ,Thornton,Congressional District 2,R,Marilinda Garcia,434.0
 ,Thornton,Congressional District 2,D,Ann McLane Kuster,547.0
 ,Thornton,Congressional District 2,,Scatter,2.0

--- a/2014/primary/20140909__nh__primary__town.csv
+++ b/2014/primary/20140909__nh__primary__town.csv
@@ -22185,7 +22185,7 @@ Sullivan,Washington,Governor,R,Scatter,1.0
 ,Plymouth,Congressional District 2,D,Marilinda Garcia,
 ,Plymouth,Congressional District 2,D,Gary Lambert,
 ,Plymouth,Congressional District 2,D,Jim Lawrence,1.0
-,Plymouth,Congressional District 2,D,Mike Little,.
+,Plymouth,Congressional District 2,D,Mike Little,
 ,Plymouth,Congressional District 2,D,Scatter,1.0
 ,Randolph,Congressional District 2,D,Ann McLane Kuster,29.0
 ,Randolph,Congressional District 2,D,Marilinda Garcia,

--- a/2016/20161108__nh__general__town.csv
+++ b/2016/20161108__nh__general__town.csv
@@ -4856,7 +4856,7 @@ Hillsborough,Peterborough,USS,,,
 Hillsborough,Peterborough,USS,,,
 Hillsborough,Peterborough,USS,,,
 Hillsborough,Peterborough,USS,,,
-Hillsborough,Peterborough,USS,,,`
+Hillsborough,Peterborough,USS,,,
 Hillsborough,Sharon,USS,R,Ayotte,104
 Hillsborough,Sharon,USS,D,Hassan,129
 Hillsborough,Sharon,USS,LIB,Chabot,9
@@ -8889,22 +8889,22 @@ Sullivan,Totals,President,,"Vakil, Kora Roberta Katz",45
 ,Atkinson,Congressional District 2,D,Ann McLane Kuster,1647
 ,Atkinson,Congressional District 2,IND,John J. Babiarz,184
 ,Atkinson,Congressional District 2,,Scatter,1
-,At. & Gil Ac. Gt,Congressional District 2,R,Jim Lawrence,--
-,At. & Gil Ac. Gt,Congressional District 2,D,Ann McLane Kuster,--
+,At. & Gil Ac. Gt,Congressional District 2,R,Jim Lawrence,
+,At. & Gil Ac. Gt,Congressional District 2,D,Ann McLane Kuster,
 ,At. & Gil Ac. Gt,Congressional District 2,IND,John J. Babiarz,
-,At. & Gil Ac. Gt,Congressional District 2,,Scatter,--
+,At. & Gil Ac. Gt,Congressional District 2,,Scatter,
 ,Bath,Congressional District 2,R,Jim Lawrence,273
 ,Bath,Congressional District 2,D,Ann McLane Kuster,233
 ,Bath,Congressional District 2,IND,John J. Babiarz,29
 ,Bath,Congressional District 2,,Scatter,
-,Bean's Grant,Congressional District 2,R,Jim Lawrence,--
-,Bean's Grant,Congressional District 2,D,Ann McLane Kuster,--
+,Bean's Grant,Congressional District 2,R,Jim Lawrence,
+,Bean's Grant,Congressional District 2,D,Ann McLane Kuster,
 ,Bean's Grant,Congressional District 2,IND,John J. Babiarz,
-,Bean's Grant,Congressional District 2,,Scatter,--
-,Bean's Purchase,Congressional District 2,R,Jim Lawrence,--
-,Bean's Purchase,Congressional District 2,D,Ann McLane Kuster,--
+,Bean's Grant,Congressional District 2,,Scatter,
+,Bean's Purchase,Congressional District 2,R,Jim Lawrence,
+,Bean's Purchase,Congressional District 2,D,Ann McLane Kuster,
 ,Bean's Purchase,Congressional District 2,IND,John J. Babiarz,
-,Bean's Purchase,Congressional District 2,,Scatter,--
+,Bean's Purchase,Congressional District 2,,Scatter,
 ,Bennington,Congressional District 2,R,Jim Lawrence,370
 ,Bennington,Congressional District 2,D,Ann McLane Kuster,336
 ,Bennington,Congressional District 2,IND,John J. Babiarz,77
@@ -8965,10 +8965,10 @@ Sullivan,Totals,President,,"Vakil, Kora Roberta Katz",45
 ,Center Harbor,Congressional District 2,D,Ann McLane Kuster,326
 ,Center Harbor,Congressional District 2,IND,John J. Babiarz,20
 ,Center Harbor,Congressional District 2,,Scatter,3
-,Chandler's Purchase,Congressional District 2,R,Jim Lawrence,--
-,Chandler's Purchase,Congressional District 2,D,Ann McLane Kuster,--
+,Chandler's Purchase,Congressional District 2,R,Jim Lawrence,
+,Chandler's Purchase,Congressional District 2,D,Ann McLane Kuster,
 ,Chandler's Purchase,Congressional District 2,IND,John J. Babiarz,
-,Chandler's Purchase,Congressional District 2,,Scatter,--
+,Chandler's Purchase,Congressional District 2,,Scatter,
 ,Charlestown,Congressional District 2,R,Jim Lawrence,1042
 ,Charlestown,Congressional District 2,D,Ann McLane Kuster,1150
 ,Charlestown,Congressional District 2,IND,John J. Babiarz,108
@@ -9049,18 +9049,18 @@ Sullivan,Totals,President,,"Vakil, Kora Roberta Katz",45
 ,Cornish,Congressional District 2,D,Ann McLane Kuster,573
 ,Cornish,Congressional District 2,IND,John J. Babiarz,45
 ,Cornish,Congressional District 2,,Scatter,
-,Crawford's Purchase,Congressional District 2,R,Jim Lawrence,--
-,Crawford's Purchase,Congressional District 2,D,Ann McLane Kuster,--
+,Crawford's Purchase,Congressional District 2,R,Jim Lawrence,
+,Crawford's Purchase,Congressional District 2,D,Ann McLane Kuster,
 ,Crawford's Purchase,Congressional District 2,IND,John J. Babiarz,
-,Crawford's Purchase,Congressional District 2,,Scatter,--
+,Crawford's Purchase,Congressional District 2,,Scatter,
 ,Croydon,Congressional District 2,R,Jim Lawrence,246
 ,Croydon,Congressional District 2,D,Ann McLane Kuster,139
 ,Croydon,Congressional District 2,IND,John J. Babiarz,19
 ,Croydon,Congressional District 2,,Scatter,
-,Cutt's Grant,Congressional District 2,R,Jim Lawrence,--
-,Cutt's Grant,Congressional District 2,D,Ann McLane Kuster,--
+,Cutt's Grant,Congressional District 2,R,Jim Lawrence,
+,Cutt's Grant,Congressional District 2,D,Ann McLane Kuster,
 ,Cutt's Grant,Congressional District 2,IND,John J. Babiarz,
-,Cutt's Grant,Congressional District 2,,Scatter,--
+,Cutt's Grant,Congressional District 2,,Scatter,
 ,Dalton,Congressional District 2,R,Jim Lawrence,252
 ,Dalton,Congressional District 2,D,Ann McLane Kuster,213
 ,Dalton,Congressional District 2,IND,John J. Babiarz,22
@@ -9077,10 +9077,10 @@ Sullivan,Totals,President,,"Vakil, Kora Roberta Katz",45
 ,Deering,Congressional District 2,D,Ann McLane Kuster,395
 ,Deering,Congressional District 2,IND,John J. Babiarz,66
 ,Deering,Congressional District 2,,Scatter,2
-,Dix's Grant,Congressional District 2,R,Jim Lawrence,--
-,Dix's Grant,Congressional District 2,D,Ann McLane Kuster,--
+,Dix's Grant,Congressional District 2,R,Jim Lawrence,
+,Dix's Grant,Congressional District 2,D,Ann McLane Kuster,
 ,Dix's Grant,Congressional District 2,IND,John J. Babiarz,
-,Dix's Grant,Congressional District 2,,Scatter,--
+,Dix's Grant,Congressional District 2,,Scatter,
 ,Dixville,Congressional District 2,R,Jim Lawrence,4
 ,Dixville,Congressional District 2,D,Ann McLane Kuster,4
 ,Dixville,Congressional District 2,IND,John J. Babiarz,0
@@ -9121,10 +9121,10 @@ Sullivan,Totals,President,,"Vakil, Kora Roberta Katz",45
 ,Errol,Congressional District 2,D,Ann McLane Kuster,62
 ,Errol,Congressional District 2,IND,John J. Babiarz,8
 ,Errol,Congressional District 2,,Scatter,
-,Erving's Location,Congressional District 2,R,Jim Lawrence,--
-,Erving's Location,Congressional District 2,D,Ann McLane Kuster,--
+,Erving's Location,Congressional District 2,R,Jim Lawrence,
+,Erving's Location,Congressional District 2,D,Ann McLane Kuster,
 ,Erving's Location,Congressional District 2,IND,John J. Babiarz,
-,Erving's Location,Congressional District 2,,Scatter,--
+,Erving's Location,Congressional District 2,,Scatter,
 ,Fitzwilliam,Congressional District 2,R,Jim Lawrence,565
 ,Fitzwilliam,Congressional District 2,D,Ann McLane Kuster,576
 ,Fitzwilliam,Congressional District 2,IND,John J. Babiarz,78
@@ -9185,10 +9185,10 @@ Sullivan,Totals,President,,"Vakil, Kora Roberta Katz",45
 ,Groton,Congressional District 2,D,Ann McLane Kuster,118
 ,Groton,Congressional District 2,IND,John J. Babiarz,20
 ,Groton,Congressional District 2,,Scatter,
-,Hadley's Purchase,Congressional District 2,R,Jim Lawrence,--
-,Hadley's Purchase,Congressional District 2,D,Ann McLane Kuster,--
+,Hadley's Purchase,Congressional District 2,R,Jim Lawrence,
+,Hadley's Purchase,Congressional District 2,D,Ann McLane Kuster,
 ,Hadley's Purchase,Congressional District 2,IND,John J. Babiarz,
-,Hadley's Purchase,Congressional District 2,,Scatter,--
+,Hadley's Purchase,Congressional District 2,,Scatter,
 ,Hancock,Congressional District 2,R,Jim Lawrence,456
 ,Hancock,Congressional District 2,D,Ann McLane Kuster,712
 ,Hancock,Congressional District 2,IND,John J. Babiarz,34
@@ -9269,10 +9269,10 @@ Sullivan,Totals,President,,"Vakil, Kora Roberta Katz",45
 ,Keene - Ward 5,Congressional District 2,D,Ann McLane Kuster,1769
 ,Keene - Ward 5,Congressional District 2,IND,John J. Babiarz,101
 ,Keene - Ward 5,Congressional District 2,,Scatter,2
-,Kilkenny,Congressional District 2,R,Jim Lawrence,--
-,Kilkenny,Congressional District 2,D,Ann McLane Kuster,--
+,Kilkenny,Congressional District 2,R,Jim Lawrence,
+,Kilkenny,Congressional District 2,D,Ann McLane Kuster,
 ,Kilkenny,Congressional District 2,IND,John J. Babiarz,
-,Kilkenny,Congressional District 2,,Scatter,--
+,Kilkenny,Congressional District 2,,Scatter,
 ,Lancaster,Congressional District 2,R,Jim Lawrence,765
 ,Lancaster,Congressional District 2,D,Ann McLane Kuster,741
 ,Lancaster,Congressional District 2,IND,John J. Babiarz,71
@@ -9317,18 +9317,18 @@ Sullivan,Totals,President,,"Vakil, Kora Roberta Katz",45
 ,Littleton,Congressional District 2,D,Ann McLane Kuster,1344
 ,Littleton,Congressional District 2,IND,John J. Babiarz,115
 ,Littleton,Congressional District 2,,Scatter,2
-,Livermore,Congressional District 2,R,Jim Lawrence,--
-,Livermore,Congressional District 2,D,Ann McLane Kuster,--
+,Livermore,Congressional District 2,R,Jim Lawrence,
+,Livermore,Congressional District 2,D,Ann McLane Kuster,
 ,Livermore,Congressional District 2,IND,John J. Babiarz,
-,Livermore,Congressional District 2,,Scatter,--
+,Livermore,Congressional District 2,,Scatter,
 ,Loudon,Congressional District 2,R,Jim Lawrence,1740
 ,Loudon,Congressional District 2,D,Ann McLane Kuster,1254
 ,Loudon,Congressional District 2,IND,John J. Babiarz,167
 ,Loudon,Congressional District 2,,Scatter,1
-,Low & Burbank's Grant,Congressional District 2,R,Jim Lawrence,--
-,Low & Burbank's Grant,Congressional District 2,D,Ann McLane Kuster,--
+,Low & Burbank's Grant,Congressional District 2,R,Jim Lawrence,
+,Low & Burbank's Grant,Congressional District 2,D,Ann McLane Kuster,
 ,Low & Burbank's Grant,Congressional District 2,IND,John J. Babiarz,
-,Low & Burbank's Grant,Congressional District 2,,Scatter,--
+,Low & Burbank's Grant,Congressional District 2,,Scatter,
 ,Lyman,Congressional District 2,R,Jim Lawrence,160
 ,Lyman,Congressional District 2,D,Ann McLane Kuster,147
 ,Lyman,Congressional District 2,IND,John J. Babiarz,7
@@ -9349,10 +9349,10 @@ Sullivan,Totals,President,,"Vakil, Kora Roberta Katz",45
 ,Marlow,Congressional District 2,D,Ann McLane Kuster,224
 ,Marlow,Congressional District 2,IND,John J. Babiarz,28
 ,Marlow,Congressional District 2,,Scatter,1
-,Martin's Location,Congressional District 2,R,Jim Lawrence,--
-,Martin's Location,Congressional District 2,D,Ann McLane Kuster,--
+,Martin's Location,Congressional District 2,R,Jim Lawrence,
+,Martin's Location,Congressional District 2,D,Ann McLane Kuster,
 ,Martin's Location,Congressional District 2,IND,John J. Babiarz,
-,Martin's Location,Congressional District 2,,Scatter,--
+,Martin's Location,Congressional District 2,,Scatter,
 ,Mason,Congressional District 2,R,Jim Lawrence,452
 ,Mason,Congressional District 2,D,Ann McLane Kuster,313
 ,Mason,Congressional District 2,IND,John J. Babiarz,56
@@ -9449,10 +9449,10 @@ Sullivan,Totals,President,,"Vakil, Kora Roberta Katz",45
 ,Northwood,Congressional District 2,D,Ann McLane Kuster,1063
 ,Northwood,Congressional District 2,IND,John J. Babiarz,155
 ,Northwood,Congressional District 2,,Scatter,2
-,Odell,Congressional District 2,R,Jim Lawrence,--
-,Odell,Congressional District 2,D,Ann McLane Kuster,--
+,Odell,Congressional District 2,R,Jim Lawrence,
+,Odell,Congressional District 2,D,Ann McLane Kuster,
 ,Odell,Congressional District 2,IND,John J. Babiarz,
-,Odell,Congressional District 2,,Scatter,--
+,Odell,Congressional District 2,,Scatter,
 ,Orange,Congressional District 2,R,Jim Lawrence,73
 ,Orange,Congressional District 2,D,Ann McLane Kuster,85
 ,Orange,Congressional District 2,IND,John J. Babiarz,12
@@ -9480,7 +9480,7 @@ Sullivan,Totals,President,,"Vakil, Kora Roberta Katz",45
 ,Pinkham's Grant,Congressional District 2,R,Jim Lawrence,1
 ,Pinkham's Grant,Congressional District 2,D,Ann McLane Kuster,3
 ,Pinkham's Grant,Congressional District 2,IND,John J. Babiarz,0
-,Pinkham's Grant,Congressional District 2,,Scatter,--
+,Pinkham's Grant,Congressional District 2,,Scatter,
 ,Pittsburg,Congressional District 2,R,Jim Lawrence,290
 ,Pittsburg,Congressional District 2,D,Ann McLane Kuster,146
 ,Pittsburg,Congressional District 2,IND,John J. Babiarz,13
@@ -9525,14 +9525,14 @@ Sullivan,Totals,President,,"Vakil, Kora Roberta Katz",45
 ,Salisbury,Congressional District 2,D,Ann McLane Kuster,322
 ,Salisbury,Congressional District 2,IND,John J. Babiarz,34
 ,Salisbury,Congressional District 2,,Scatter,
-,Sargent's Purchase,Congressional District 2,R,Jim Lawrence,--
-,Sargent's Purchase,Congressional District 2,D,Ann McLane Kuster,--
+,Sargent's Purchase,Congressional District 2,R,Jim Lawrence,
+,Sargent's Purchase,Congressional District 2,D,Ann McLane Kuster,
 ,Sargent's Purchase,Congressional District 2,IND,John J. Babiarz,
-,Sargent's Purchase,Congressional District 2,,Scatter,--
-,Second College Grant,Congressional District 2,R,Jim Lawrence,--
-,Second College Grant,Congressional District 2,D,Ann McLane Kuster,--
+,Sargent's Purchase,Congressional District 2,,Scatter,
+,Second College Grant,Congressional District 2,R,Jim Lawrence,
+,Second College Grant,Congressional District 2,D,Ann McLane Kuster,
 ,Second College Grant,Congressional District 2,IND,John J. Babiarz,
-,Second College Grant,Congressional District 2,,Scatter,--
+,Second College Grant,Congressional District 2,,Scatter,
 ,Sharon,Congressional District 2,R,Jim Lawrence,99
 ,Sharon,Congressional District 2,D,Ann McLane Kuster,135
 ,Sharon,Congressional District 2,IND,John J. Babiarz,12
@@ -9561,10 +9561,10 @@ Sullivan,Totals,President,,"Vakil, Kora Roberta Katz",45
 ,Stratford,Congressional District 2,D,Ann McLane Kuster,137
 ,Stratford,Congressional District 2,IND,John J. Babiarz,22
 ,Stratford,Congressional District 2,,Scatter,
-,Success,Congressional District 2,R,Jim Lawrence,--
-,Success,Congressional District 2,D,Ann McLane Kuster,--
+,Success,Congressional District 2,R,Jim Lawrence,
+,Success,Congressional District 2,D,Ann McLane Kuster,
 ,Success,Congressional District 2,IND,John J. Babiarz,
-,Success,Congressional District 2,,Scatter,--
+,Success,Congressional District 2,,Scatter,
 ,Sugar Hill,Congressional District 2,R,Jim Lawrence,165
 ,Sugar Hill,Congressional District 2,D,Ann McLane Kuster,242
 ,Sugar Hill,Congressional District 2,IND,John J. Babiarz,9
@@ -9593,10 +9593,10 @@ Sullivan,Totals,President,,"Vakil, Kora Roberta Katz",45
 ,Temple,Congressional District 2,D,Ann McLane Kuster,411
 ,Temple,Congressional District 2,IND,John J. Babiarz,44
 ,Temple,Congressional District 2,,Scatter,3
-,Thomp. and Mes's Pur.,Congressional District 2,R,Jim Lawrence,--
-,Thomp. and Mes's Pur.,Congressional District 2,D,Ann McLane Kuster,--
+,Thomp. and Mes's Pur.,Congressional District 2,R,Jim Lawrence,
+,Thomp. and Mes's Pur.,Congressional District 2,D,Ann McLane Kuster,
 ,Thomp. and Mes's Pur.,Congressional District 2,IND,John J. Babiarz,
-,Thomp. and Mes's Pur.,Congressional District 2,,Scatter,--
+,Thomp. and Mes's Pur.,Congressional District 2,,Scatter,
 ,Thornton,Congressional District 2,R,Jim Lawrence,625
 ,Thornton,Congressional District 2,D,Ann McLane Kuster,724
 ,Thornton,Congressional District 2,IND,John J. Babiarz,102

--- a/2020/20200211__nh__primary__president__town.csv
+++ b/2020/20200211__nh__primary__president__town.csv
@@ -4878,7 +4878,7 @@ Hillsborough,Manchester Ward 9,President,,DEM,Michael Bennet,4
 Hillsborough,Manchester Ward 10,President,,DEM,Michael Bennet,5
 Hillsborough,Manchester Ward 11,President,,DEM,Michael Bennet,5
 Hillsborough,Manchester Ward 12,President,,DEM,Michael Bennet,8
-Hillsborough,Mason,President,,DEM,Michael Bennet,-
+Hillsborough,Mason,President,,DEM,Michael Bennet,
 Hillsborough,Merrimack,President,,DEM,Michael Bennet,28
 Hillsborough,Milford,President,,DEM,Michael Bennet,9
 Hillsborough,Mont Vernon,President,,DEM,Michael Bennet,3
@@ -4886,7 +4886,7 @@ Hillsborough,Nashua -Ward 1,President,,DEM,Michael Bennet,10
 Hillsborough,Nashua -Ward 2,President,,DEM,Michael Bennet,5
 Hillsborough,Nashua- Ward 3,President,,DEM,Michael Bennet,12
 Hillsborough,Nashua -Ward 4,President,,DEM,Michael Bennet,1
-Hillsborough,Nashua -Ward 5,President,,DEM,Michael Bennet,-
+Hillsborough,Nashua -Ward 5,President,,DEM,Michael Bennet,
 Hillsborough,Nashua -Ward 6,President,,DEM,Michael Bennet,5
 Hillsborough,Nashua -Ward 7,President,,DEM,Michael Bennet,3
 Hillsborough,Nashua- Ward 8,President,,DEM,Michael Bennet,8
@@ -4895,11 +4895,11 @@ Hillsborough,New Boston,President,,DEM,Michael Bennet,2
 Hillsborough,New Ipswich,President,,DEM,Michael Bennet,3
 Hillsborough,Pelham,President,,DEM,Michael Bennet,10
 Hillsborough,Peter-borough,President,,DEM,Michael Bennet,5
-Hillsborough,Sharon,President,,DEM,Michael Bennet,-
+Hillsborough,Sharon,President,,DEM,Michael Bennet,
 Hillsborough,Temple,President,,DEM,Michael Bennet,1
 Hillsborough,Weare,President,,DEM,Michael Bennet,3
 Hillsborough,Wilton,President,,DEM,Michael Bennet,4
-Hillsborough,Windsor,President,,DEM,Michael Bennet,-
+Hillsborough,Windsor,President,,DEM,Michael Bennet,
 Hillsborough,Amherst,President,,DEM,Joe Biden,305
 Hillsborough,Antrim,President,,DEM,Joe Biden,35
 Hillsborough,Bedford,President,,DEM,Joe Biden,451
@@ -4977,29 +4977,29 @@ Hillsborough,Manchester Ward 8,President,,DEM,Cory Booker,2
 Hillsborough,Manchester Ward 9,President,,DEM,Cory Booker,1
 Hillsborough,Manchester Ward 10,President,,DEM,Cory Booker,1
 Hillsborough,Manchester Ward 11,President,,DEM,Cory Booker,1
-Hillsborough,Manchester Ward 12,President,,DEM,Cory Booker,-
+Hillsborough,Manchester Ward 12,President,,DEM,Cory Booker,
 Hillsborough,Mason,President,,DEM,Cory Booker,1
 Hillsborough,Merrimack,President,,DEM,Cory Booker,2
 Hillsborough,Milford,President,,DEM,Cory Booker,2
-Hillsborough,Mont Vernon,President,,DEM,Cory Booker,-
+Hillsborough,Mont Vernon,President,,DEM,Cory Booker,
 Hillsborough,Nashua -Ward 1,President,,DEM,Cory Booker,1
 Hillsborough,Nashua -Ward 2,President,,DEM,Cory Booker,2
 Hillsborough,Nashua- Ward 3,President,,DEM,Cory Booker,2
 Hillsborough,Nashua -Ward 4,President,,DEM,Cory Booker,2
 Hillsborough,Nashua -Ward 5,President,,DEM,Cory Booker,1
-Hillsborough,Nashua -Ward 6,President,,DEM,Cory Booker,-
+Hillsborough,Nashua -Ward 6,President,,DEM,Cory Booker,
 Hillsborough,Nashua -Ward 7,President,,DEM,Cory Booker,2
 Hillsborough,Nashua- Ward 8,President,,DEM,Cory Booker,2
-Hillsborough,Nashua -Ward 9,President,,DEM,Cory Booker,-
-Hillsborough,New Boston,President,,DEM,Cory Booker,-
-Hillsborough,New Ipswich,President,,DEM,Cory Booker,-
+Hillsborough,Nashua -Ward 9,President,,DEM,Cory Booker,
+Hillsborough,New Boston,President,,DEM,Cory Booker,
+Hillsborough,New Ipswich,President,,DEM,Cory Booker,
 Hillsborough,Pelham,President,,DEM,Cory Booker,1
 Hillsborough,Peter-borough,President,,DEM,Cory Booker,2
-Hillsborough,Sharon,President,,DEM,Cory Booker,-
-Hillsborough,Temple,President,,DEM,Cory Booker,-
+Hillsborough,Sharon,President,,DEM,Cory Booker,
+Hillsborough,Temple,President,,DEM,Cory Booker,
 Hillsborough,Weare,President,,DEM,Cory Booker,2
-Hillsborough,Wilton,President,,DEM,Cory Booker,-
-Hillsborough,Windsor,President,,DEM,Cory Booker,-
+Hillsborough,Wilton,President,,DEM,Cory Booker,
+Hillsborough,Windsor,President,,DEM,Cory Booker,
 Hillsborough,Amherst,President,,DEM,Boyd,0
 Hillsborough,Antrim,President,,DEM,Boyd,0
 Hillsborough,Bedford,President,,DEM,Boyd,2
@@ -5025,31 +5025,31 @@ Hillsborough,Manchester Ward 6,President,,DEM,Boyd,0
 Hillsborough,Manchester Ward 7,President,,DEM,Boyd,0
 Hillsborough,Manchester Ward 8,President,,DEM,Boyd,0
 Hillsborough,Manchester Ward 9,President,,DEM,Boyd,0
-Hillsborough,Manchester Ward 10,President,,DEM,Boyd,-
-Hillsborough,Manchester Ward 11,President,,DEM,Boyd,-
+Hillsborough,Manchester Ward 10,President,,DEM,Boyd,
+Hillsborough,Manchester Ward 11,President,,DEM,Boyd,
 Hillsborough,Manchester Ward 12,President,,DEM,Boyd,1
-Hillsborough,Mason,President,,DEM,Boyd,-
-Hillsborough,Merrimack,President,,DEM,Boyd,-
+Hillsborough,Mason,President,,DEM,Boyd,
+Hillsborough,Merrimack,President,,DEM,Boyd,
 Hillsborough,Milford,President,,DEM,Boyd,1
-Hillsborough,Mont Vernon,President,,DEM,Boyd,-
-Hillsborough,Nashua -Ward 1,President,,DEM,Boyd,-
-Hillsborough,Nashua -Ward 2,President,,DEM,Boyd,-
-Hillsborough,Nashua- Ward 3,President,,DEM,Boyd,-
-Hillsborough,Nashua -Ward 4,President,,DEM,Boyd,-
-Hillsborough,Nashua -Ward 5,President,,DEM,Boyd,-
-Hillsborough,Nashua -Ward 6,President,,DEM,Boyd,-
-Hillsborough,Nashua -Ward 7,President,,DEM,Boyd,-
-Hillsborough,Nashua- Ward 8,President,,DEM,Boyd,-
-Hillsborough,Nashua -Ward 9,President,,DEM,Boyd,-
-Hillsborough,New Boston,President,,DEM,Boyd,-
-Hillsborough,New Ipswich,President,,DEM,Boyd,-
-Hillsborough,Pelham,President,,DEM,Boyd,-
-Hillsborough,Peter-borough,President,,DEM,Boyd,-
-Hillsborough,Sharon,President,,DEM,Boyd,-
-Hillsborough,Temple,President,,DEM,Boyd,-
-Hillsborough,Weare,President,,DEM,Boyd,-
-Hillsborough,Wilton,President,,DEM,Boyd,-
-Hillsborough,Windsor,President,,DEM,Boyd,-
+Hillsborough,Mont Vernon,President,,DEM,Boyd,
+Hillsborough,Nashua -Ward 1,President,,DEM,Boyd,
+Hillsborough,Nashua -Ward 2,President,,DEM,Boyd,
+Hillsborough,Nashua- Ward 3,President,,DEM,Boyd,
+Hillsborough,Nashua -Ward 4,President,,DEM,Boyd,
+Hillsborough,Nashua -Ward 5,President,,DEM,Boyd,
+Hillsborough,Nashua -Ward 6,President,,DEM,Boyd,
+Hillsborough,Nashua -Ward 7,President,,DEM,Boyd,
+Hillsborough,Nashua- Ward 8,President,,DEM,Boyd,
+Hillsborough,Nashua -Ward 9,President,,DEM,Boyd,
+Hillsborough,New Boston,President,,DEM,Boyd,
+Hillsborough,New Ipswich,President,,DEM,Boyd,
+Hillsborough,Pelham,President,,DEM,Boyd,
+Hillsborough,Peter-borough,President,,DEM,Boyd,
+Hillsborough,Sharon,President,,DEM,Boyd,
+Hillsborough,Temple,President,,DEM,Boyd,
+Hillsborough,Weare,President,,DEM,Boyd,
+Hillsborough,Wilton,President,,DEM,Boyd,
+Hillsborough,Windsor,President,,DEM,Boyd,
 Hillsborough,Amherst,President,,DEM,Steve Bullock,0
 Hillsborough,Antrim,President,,DEM,Steve Bullock,0
 Hillsborough,Bedford,President,,DEM,Steve Bullock,0
@@ -5076,30 +5076,30 @@ Hillsborough,Manchester Ward 7,President,,DEM,Steve Bullock,0
 Hillsborough,Manchester Ward 8,President,,DEM,Steve Bullock,1
 Hillsborough,Manchester Ward 9,President,,DEM,Steve Bullock,0
 Hillsborough,Manchester Ward 10,President,,DEM,Steve Bullock,2
-Hillsborough,Manchester Ward 11,President,,DEM,Steve Bullock,-
-Hillsborough,Manchester Ward 12,President,,DEM,Steve Bullock,-
-Hillsborough,Mason,President,,DEM,Steve Bullock,-
+Hillsborough,Manchester Ward 11,President,,DEM,Steve Bullock,
+Hillsborough,Manchester Ward 12,President,,DEM,Steve Bullock,
+Hillsborough,Mason,President,,DEM,Steve Bullock,
 Hillsborough,Merrimack,President,,DEM,Steve Bullock,1
 Hillsborough,Milford,President,,DEM,Steve Bullock,1
-Hillsborough,Mont Vernon,President,,DEM,Steve Bullock,-
-Hillsborough,Nashua -Ward 1,President,,DEM,Steve Bullock,-
+Hillsborough,Mont Vernon,President,,DEM,Steve Bullock,
+Hillsborough,Nashua -Ward 1,President,,DEM,Steve Bullock,
 Hillsborough,Nashua -Ward 2,President,,DEM,Steve Bullock,1
-Hillsborough,Nashua- Ward 3,President,,DEM,Steve Bullock,-
-Hillsborough,Nashua -Ward 4,President,,DEM,Steve Bullock,-
-Hillsborough,Nashua -Ward 5,President,,DEM,Steve Bullock,-
-Hillsborough,Nashua -Ward 6,President,,DEM,Steve Bullock,-
-Hillsborough,Nashua -Ward 7,President,,DEM,Steve Bullock,-
-Hillsborough,Nashua- Ward 8,President,,DEM,Steve Bullock,-
-Hillsborough,Nashua -Ward 9,President,,DEM,Steve Bullock,-
-Hillsborough,New Boston,President,,DEM,Steve Bullock,-
+Hillsborough,Nashua- Ward 3,President,,DEM,Steve Bullock,
+Hillsborough,Nashua -Ward 4,President,,DEM,Steve Bullock,
+Hillsborough,Nashua -Ward 5,President,,DEM,Steve Bullock,
+Hillsborough,Nashua -Ward 6,President,,DEM,Steve Bullock,
+Hillsborough,Nashua -Ward 7,President,,DEM,Steve Bullock,
+Hillsborough,Nashua- Ward 8,President,,DEM,Steve Bullock,
+Hillsborough,Nashua -Ward 9,President,,DEM,Steve Bullock,
+Hillsborough,New Boston,President,,DEM,Steve Bullock,
 Hillsborough,New Ipswich,President,,DEM,Steve Bullock,1
-Hillsborough,Pelham,President,,DEM,Steve Bullock,-
-Hillsborough,Peter-borough,President,,DEM,Steve Bullock,-
-Hillsborough,Sharon,President,,DEM,Steve Bullock,-
-Hillsborough,Temple,President,,DEM,Steve Bullock,-
+Hillsborough,Pelham,President,,DEM,Steve Bullock,
+Hillsborough,Peter-borough,President,,DEM,Steve Bullock,
+Hillsborough,Sharon,President,,DEM,Steve Bullock,
+Hillsborough,Temple,President,,DEM,Steve Bullock,
 Hillsborough,Weare,President,,DEM,Steve Bullock,1
 Hillsborough,Wilton,President,,DEM,Steve Bullock,1
-Hillsborough,Windsor,President,,DEM,Steve Bullock,-
+Hillsborough,Windsor,President,,DEM,Steve Bullock,
 Hillsborough,Amherst,President,,DEM,Burke,0
 Hillsborough,Antrim,President,,DEM,Burke,0
 Hillsborough,Bedford,President,,DEM,Burke,0
@@ -5125,31 +5125,31 @@ Hillsborough,Manchester Ward 6,President,,DEM,Burke,0
 Hillsborough,Manchester Ward 7,President,,DEM,Burke,0
 Hillsborough,Manchester Ward 8,President,,DEM,Burke,0
 Hillsborough,Manchester Ward 9,President,,DEM,Burke,0
-Hillsborough,Manchester Ward 10,President,,DEM,Burke,-
-Hillsborough,Manchester Ward 11,President,,DEM,Burke,-
-Hillsborough,Manchester Ward 12,President,,DEM,Burke,-
-Hillsborough,Mason,President,,DEM,Burke,-
+Hillsborough,Manchester Ward 10,President,,DEM,Burke,
+Hillsborough,Manchester Ward 11,President,,DEM,Burke,
+Hillsborough,Manchester Ward 12,President,,DEM,Burke,
+Hillsborough,Mason,President,,DEM,Burke,
 Hillsborough,Merrimack,President,,DEM,Burke,1
 Hillsborough,Milford,President,,DEM,Burke,1
-Hillsborough,Mont Vernon,President,,DEM,Burke,-
+Hillsborough,Mont Vernon,President,,DEM,Burke,
 Hillsborough,Nashua -Ward 1,President,,DEM,Burke,1
 Hillsborough,Nashua -Ward 2,President,,DEM,Burke,1
-Hillsborough,Nashua- Ward 3,President,,DEM,Burke,-
-Hillsborough,Nashua -Ward 4,President,,DEM,Burke,-
+Hillsborough,Nashua- Ward 3,President,,DEM,Burke,
+Hillsborough,Nashua -Ward 4,President,,DEM,Burke,
 Hillsborough,Nashua -Ward 5,President,,DEM,Burke,4
 Hillsborough,Nashua -Ward 6,President,,DEM,Burke,1
 Hillsborough,Nashua -Ward 7,President,,DEM,Burke,2
-Hillsborough,Nashua- Ward 8,President,,DEM,Burke,-
-Hillsborough,Nashua -Ward 9,President,,DEM,Burke,-
-Hillsborough,New Boston,President,,DEM,Burke,-
+Hillsborough,Nashua- Ward 8,President,,DEM,Burke,
+Hillsborough,Nashua -Ward 9,President,,DEM,Burke,
+Hillsborough,New Boston,President,,DEM,Burke,
 Hillsborough,New Ipswich,President,,DEM,Burke,1
 Hillsborough,Pelham,President,,DEM,Burke,1
 Hillsborough,Peter-borough,President,,DEM,Burke,2
-Hillsborough,Sharon,President,,DEM,Burke,-
-Hillsborough,Temple,President,,DEM,Burke,-
-Hillsborough,Weare,President,,DEM,Burke,-
-Hillsborough,Wilton,President,,DEM,Burke,-
-Hillsborough,Windsor,President,,DEM,Burke,-
+Hillsborough,Sharon,President,,DEM,Burke,
+Hillsborough,Temple,President,,DEM,Burke,
+Hillsborough,Weare,President,,DEM,Burke,
+Hillsborough,Wilton,President,,DEM,Burke,
+Hillsborough,Windsor,President,,DEM,Burke,
 Hillsborough,Amherst,President,,DEM,Pete Buttigieg,1005
 Hillsborough,Antrim,President,,DEM,Pete Buttigieg,116
 Hillsborough,Bedford,President,,DEM,Pete Buttigieg,1302
@@ -5226,30 +5226,30 @@ Hillsborough,Manchester Ward 7,President,,DEM,Julian Castro,1
 Hillsborough,Manchester Ward 8,President,,DEM,Julian Castro,1
 Hillsborough,Manchester Ward 9,President,,DEM,Julian Castro,4
 Hillsborough,Manchester Ward 10,President,,DEM,Julian Castro,1
-Hillsborough,Manchester Ward 11,President,,DEM,Julian Castro,-
-Hillsborough,Manchester Ward 12,President,,DEM,Julian Castro,-
-Hillsborough,Mason,President,,DEM,Julian Castro,-
+Hillsborough,Manchester Ward 11,President,,DEM,Julian Castro,
+Hillsborough,Manchester Ward 12,President,,DEM,Julian Castro,
+Hillsborough,Mason,President,,DEM,Julian Castro,
 Hillsborough,Merrimack,President,,DEM,Julian Castro,2
 Hillsborough,Milford,President,,DEM,Julian Castro,1
-Hillsborough,Mont Vernon,President,,DEM,Julian Castro,-
-Hillsborough,Nashua -Ward 1,President,,DEM,Julian Castro,-
-Hillsborough,Nashua -Ward 2,President,,DEM,Julian Castro,-
-Hillsborough,Nashua- Ward 3,President,,DEM,Julian Castro,-
+Hillsborough,Mont Vernon,President,,DEM,Julian Castro,
+Hillsborough,Nashua -Ward 1,President,,DEM,Julian Castro,
+Hillsborough,Nashua -Ward 2,President,,DEM,Julian Castro,
+Hillsborough,Nashua- Ward 3,President,,DEM,Julian Castro,
 Hillsborough,Nashua -Ward 4,President,,DEM,Julian Castro,2
-Hillsborough,Nashua -Ward 5,President,,DEM,Julian Castro,-
+Hillsborough,Nashua -Ward 5,President,,DEM,Julian Castro,
 Hillsborough,Nashua -Ward 6,President,,DEM,Julian Castro,1
 Hillsborough,Nashua -Ward 7,President,,DEM,Julian Castro,2
-Hillsborough,Nashua- Ward 8,President,,DEM,Julian Castro,-
-Hillsborough,Nashua -Ward 9,President,,DEM,Julian Castro,-
-Hillsborough,New Boston,President,,DEM,Julian Castro,-
+Hillsborough,Nashua- Ward 8,President,,DEM,Julian Castro,
+Hillsborough,Nashua -Ward 9,President,,DEM,Julian Castro,
+Hillsborough,New Boston,President,,DEM,Julian Castro,
 Hillsborough,New Ipswich,President,,DEM,Julian Castro,1
-Hillsborough,Pelham,President,,DEM,Julian Castro,-
-Hillsborough,Peter-borough,President,,DEM,Julian Castro,-
-Hillsborough,Sharon,President,,DEM,Julian Castro,-
-Hillsborough,Temple,President,,DEM,Julian Castro,-
-Hillsborough,Weare,President,,DEM,Julian Castro,-
-Hillsborough,Wilton,President,,DEM,Julian Castro,-
-Hillsborough,Windsor,President,,DEM,Julian Castro,-
+Hillsborough,Pelham,President,,DEM,Julian Castro,
+Hillsborough,Peter-borough,President,,DEM,Julian Castro,
+Hillsborough,Sharon,President,,DEM,Julian Castro,
+Hillsborough,Temple,President,,DEM,Julian Castro,
+Hillsborough,Weare,President,,DEM,Julian Castro,
+Hillsborough,Wilton,President,,DEM,Julian Castro,
+Hillsborough,Windsor,President,,DEM,Julian Castro,
 Hillsborough,Amherst,President,,DEM,Rocky De La Fuente,0
 Hillsborough,Antrim,President,,DEM,Rocky De La Fuente,0
 Hillsborough,Bedford,President,,DEM,Rocky De La Fuente,0
@@ -5275,31 +5275,31 @@ Hillsborough,Manchester Ward 6,President,,DEM,Rocky De La Fuente,0
 Hillsborough,Manchester Ward 7,President,,DEM,Rocky De La Fuente,0
 Hillsborough,Manchester Ward 8,President,,DEM,Rocky De La Fuente,0
 Hillsborough,Manchester Ward 9,President,,DEM,Rocky De La Fuente,0
-Hillsborough,Manchester Ward 10,President,,DEM,Rocky De La Fuente,-
-Hillsborough,Manchester Ward 11,President,,DEM,Rocky De La Fuente,-
-Hillsborough,Manchester Ward 12,President,,DEM,Rocky De La Fuente,-
-Hillsborough,Mason,President,,DEM,Rocky De La Fuente,-
-Hillsborough,Merrimack,President,,DEM,Rocky De La Fuente,-
-Hillsborough,Milford,President,,DEM,Rocky De La Fuente,-
-Hillsborough,Mont Vernon,President,,DEM,Rocky De La Fuente,-
-Hillsborough,Nashua -Ward 1,President,,DEM,Rocky De La Fuente,-
-Hillsborough,Nashua -Ward 2,President,,DEM,Rocky De La Fuente,-
-Hillsborough,Nashua- Ward 3,President,,DEM,Rocky De La Fuente,-
-Hillsborough,Nashua -Ward 4,President,,DEM,Rocky De La Fuente,-
-Hillsborough,Nashua -Ward 5,President,,DEM,Rocky De La Fuente,-
-Hillsborough,Nashua -Ward 6,President,,DEM,Rocky De La Fuente,-
-Hillsborough,Nashua -Ward 7,President,,DEM,Rocky De La Fuente,-
-Hillsborough,Nashua- Ward 8,President,,DEM,Rocky De La Fuente,-
-Hillsborough,Nashua -Ward 9,President,,DEM,Rocky De La Fuente,-
-Hillsborough,New Boston,President,,DEM,Rocky De La Fuente,-
-Hillsborough,New Ipswich,President,,DEM,Rocky De La Fuente,-
-Hillsborough,Pelham,President,,DEM,Rocky De La Fuente,-
-Hillsborough,Peter-borough,President,,DEM,Rocky De La Fuente,-
-Hillsborough,Sharon,President,,DEM,Rocky De La Fuente,-
-Hillsborough,Temple,President,,DEM,Rocky De La Fuente,-
+Hillsborough,Manchester Ward 10,President,,DEM,Rocky De La Fuente,
+Hillsborough,Manchester Ward 11,President,,DEM,Rocky De La Fuente,
+Hillsborough,Manchester Ward 12,President,,DEM,Rocky De La Fuente,
+Hillsborough,Mason,President,,DEM,Rocky De La Fuente,
+Hillsborough,Merrimack,President,,DEM,Rocky De La Fuente,
+Hillsborough,Milford,President,,DEM,Rocky De La Fuente,
+Hillsborough,Mont Vernon,President,,DEM,Rocky De La Fuente,
+Hillsborough,Nashua -Ward 1,President,,DEM,Rocky De La Fuente,
+Hillsborough,Nashua -Ward 2,President,,DEM,Rocky De La Fuente,
+Hillsborough,Nashua- Ward 3,President,,DEM,Rocky De La Fuente,
+Hillsborough,Nashua -Ward 4,President,,DEM,Rocky De La Fuente,
+Hillsborough,Nashua -Ward 5,President,,DEM,Rocky De La Fuente,
+Hillsborough,Nashua -Ward 6,President,,DEM,Rocky De La Fuente,
+Hillsborough,Nashua -Ward 7,President,,DEM,Rocky De La Fuente,
+Hillsborough,Nashua- Ward 8,President,,DEM,Rocky De La Fuente,
+Hillsborough,Nashua -Ward 9,President,,DEM,Rocky De La Fuente,
+Hillsborough,New Boston,President,,DEM,Rocky De La Fuente,
+Hillsborough,New Ipswich,President,,DEM,Rocky De La Fuente,
+Hillsborough,Pelham,President,,DEM,Rocky De La Fuente,
+Hillsborough,Peter-borough,President,,DEM,Rocky De La Fuente,
+Hillsborough,Sharon,President,,DEM,Rocky De La Fuente,
+Hillsborough,Temple,President,,DEM,Rocky De La Fuente,
 Hillsborough,Weare,President,,DEM,Rocky De La Fuente,1
-Hillsborough,Wilton,President,,DEM,Rocky De La Fuente,-
-Hillsborough,Windsor,President,,DEM,Rocky De La Fuente,-
+Hillsborough,Wilton,President,,DEM,Rocky De La Fuente,
+Hillsborough,Windsor,President,,DEM,Rocky De La Fuente,
 Hillsborough,Amherst,President,,DEM,John Delaney,1
 Hillsborough,Antrim,President,,DEM,John Delaney,0
 Hillsborough,Bedford,President,,DEM,John Delaney,1
@@ -5325,31 +5325,31 @@ Hillsborough,Manchester Ward 6,President,,DEM,John Delaney,0
 Hillsborough,Manchester Ward 7,President,,DEM,John Delaney,1
 Hillsborough,Manchester Ward 8,President,,DEM,John Delaney,1
 Hillsborough,Manchester Ward 9,President,,DEM,John Delaney,3
-Hillsborough,Manchester Ward 10,President,,DEM,John Delaney,-
-Hillsborough,Manchester Ward 11,President,,DEM,John Delaney,-
-Hillsborough,Manchester Ward 12,President,,DEM,John Delaney,-
-Hillsborough,Mason,President,,DEM,John Delaney,-
+Hillsborough,Manchester Ward 10,President,,DEM,John Delaney,
+Hillsborough,Manchester Ward 11,President,,DEM,John Delaney,
+Hillsborough,Manchester Ward 12,President,,DEM,John Delaney,
+Hillsborough,Mason,President,,DEM,John Delaney,
 Hillsborough,Merrimack,President,,DEM,John Delaney,5
 Hillsborough,Milford,President,,DEM,John Delaney,2
 Hillsborough,Mont Vernon,President,,DEM,John Delaney,1
-Hillsborough,Nashua -Ward 1,President,,DEM,John Delaney,-
-Hillsborough,Nashua -Ward 2,President,,DEM,John Delaney,-
-Hillsborough,Nashua- Ward 3,President,,DEM,John Delaney,-
-Hillsborough,Nashua -Ward 4,President,,DEM,John Delaney,-
-Hillsborough,Nashua -Ward 5,President,,DEM,John Delaney,-
-Hillsborough,Nashua -Ward 6,President,,DEM,John Delaney,-
-Hillsborough,Nashua -Ward 7,President,,DEM,John Delaney,-
-Hillsborough,Nashua- Ward 8,President,,DEM,John Delaney,-
+Hillsborough,Nashua -Ward 1,President,,DEM,John Delaney,
+Hillsborough,Nashua -Ward 2,President,,DEM,John Delaney,
+Hillsborough,Nashua- Ward 3,President,,DEM,John Delaney,
+Hillsborough,Nashua -Ward 4,President,,DEM,John Delaney,
+Hillsborough,Nashua -Ward 5,President,,DEM,John Delaney,
+Hillsborough,Nashua -Ward 6,President,,DEM,John Delaney,
+Hillsborough,Nashua -Ward 7,President,,DEM,John Delaney,
+Hillsborough,Nashua- Ward 8,President,,DEM,John Delaney,
 Hillsborough,Nashua -Ward 9,President,,DEM,John Delaney,1
-Hillsborough,New Boston,President,,DEM,John Delaney,-
+Hillsborough,New Boston,President,,DEM,John Delaney,
 Hillsborough,New Ipswich,President,,DEM,John Delaney,1
-Hillsborough,Pelham,President,,DEM,John Delaney,-
-Hillsborough,Peter-borough,President,,DEM,John Delaney,-
-Hillsborough,Sharon,President,,DEM,John Delaney,-
-Hillsborough,Temple,President,,DEM,John Delaney,-
+Hillsborough,Pelham,President,,DEM,John Delaney,
+Hillsborough,Peter-borough,President,,DEM,John Delaney,
+Hillsborough,Sharon,President,,DEM,John Delaney,
+Hillsborough,Temple,President,,DEM,John Delaney,
 Hillsborough,Weare,President,,DEM,John Delaney,2
-Hillsborough,Wilton,President,,DEM,John Delaney,-
-Hillsborough,Windsor,President,,DEM,John Delaney,-
+Hillsborough,Wilton,President,,DEM,John Delaney,
+Hillsborough,Windsor,President,,DEM,John Delaney,
 Hillsborough,Amherst,President,,DEM,Dunlap,0
 Hillsborough,Antrim,President,,DEM,Dunlap,0
 Hillsborough,Bedford,President,,DEM,Dunlap,0
@@ -5375,31 +5375,31 @@ Hillsborough,Manchester Ward 6,President,,DEM,Dunlap,0
 Hillsborough,Manchester Ward 7,President,,DEM,Dunlap,0
 Hillsborough,Manchester Ward 8,President,,DEM,Dunlap,0
 Hillsborough,Manchester Ward 9,President,,DEM,Dunlap,1
-Hillsborough,Manchester Ward 10,President,,DEM,Dunlap,-
-Hillsborough,Manchester Ward 11,President,,DEM,Dunlap,-
-Hillsborough,Manchester Ward 12,President,,DEM,Dunlap,-
-Hillsborough,Mason,President,,DEM,Dunlap,-
-Hillsborough,Merrimack,President,,DEM,Dunlap,-
-Hillsborough,Milford,President,,DEM,Dunlap,-
-Hillsborough,Mont Vernon,President,,DEM,Dunlap,-
-Hillsborough,Nashua -Ward 1,President,,DEM,Dunlap,-
-Hillsborough,Nashua -Ward 2,President,,DEM,Dunlap,-
-Hillsborough,Nashua- Ward 3,President,,DEM,Dunlap,-
-Hillsborough,Nashua -Ward 4,President,,DEM,Dunlap,-
-Hillsborough,Nashua -Ward 5,President,,DEM,Dunlap,-
-Hillsborough,Nashua -Ward 6,President,,DEM,Dunlap,-
-Hillsborough,Nashua -Ward 7,President,,DEM,Dunlap,-
-Hillsborough,Nashua- Ward 8,President,,DEM,Dunlap,-
-Hillsborough,Nashua -Ward 9,President,,DEM,Dunlap,-
-Hillsborough,New Boston,President,,DEM,Dunlap,-
-Hillsborough,New Ipswich,President,,DEM,Dunlap,-
-Hillsborough,Pelham,President,,DEM,Dunlap,-
-Hillsborough,Peter-borough,President,,DEM,Dunlap,-
-Hillsborough,Sharon,President,,DEM,Dunlap,-
-Hillsborough,Temple,President,,DEM,Dunlap,-
-Hillsborough,Weare,President,,DEM,Dunlap,-
-Hillsborough,Wilton,President,,DEM,Dunlap,-
-Hillsborough,Windsor,President,,DEM,Dunlap,-
+Hillsborough,Manchester Ward 10,President,,DEM,Dunlap,
+Hillsborough,Manchester Ward 11,President,,DEM,Dunlap,
+Hillsborough,Manchester Ward 12,President,,DEM,Dunlap,
+Hillsborough,Mason,President,,DEM,Dunlap,
+Hillsborough,Merrimack,President,,DEM,Dunlap,
+Hillsborough,Milford,President,,DEM,Dunlap,
+Hillsborough,Mont Vernon,President,,DEM,Dunlap,
+Hillsborough,Nashua -Ward 1,President,,DEM,Dunlap,
+Hillsborough,Nashua -Ward 2,President,,DEM,Dunlap,
+Hillsborough,Nashua- Ward 3,President,,DEM,Dunlap,
+Hillsborough,Nashua -Ward 4,President,,DEM,Dunlap,
+Hillsborough,Nashua -Ward 5,President,,DEM,Dunlap,
+Hillsborough,Nashua -Ward 6,President,,DEM,Dunlap,
+Hillsborough,Nashua -Ward 7,President,,DEM,Dunlap,
+Hillsborough,Nashua- Ward 8,President,,DEM,Dunlap,
+Hillsborough,Nashua -Ward 9,President,,DEM,Dunlap,
+Hillsborough,New Boston,President,,DEM,Dunlap,
+Hillsborough,New Ipswich,President,,DEM,Dunlap,
+Hillsborough,Pelham,President,,DEM,Dunlap,
+Hillsborough,Peter-borough,President,,DEM,Dunlap,
+Hillsborough,Sharon,President,,DEM,Dunlap,
+Hillsborough,Temple,President,,DEM,Dunlap,
+Hillsborough,Weare,President,,DEM,Dunlap,
+Hillsborough,Wilton,President,,DEM,Dunlap,
+Hillsborough,Windsor,President,,DEM,Dunlap,
 Hillsborough,Amherst,President,,DEM,Ellinger,0
 Hillsborough,Antrim,President,,DEM,Ellinger,0
 Hillsborough,Bedford,President,,DEM,Ellinger,0
@@ -5425,31 +5425,31 @@ Hillsborough,Manchester Ward 6,President,,DEM,Ellinger,0
 Hillsborough,Manchester Ward 7,President,,DEM,Ellinger,0
 Hillsborough,Manchester Ward 8,President,,DEM,Ellinger,0
 Hillsborough,Manchester Ward 9,President,,DEM,Ellinger,0
-Hillsborough,Manchester Ward 10,President,,DEM,Ellinger,-
-Hillsborough,Manchester Ward 11,President,,DEM,Ellinger,-
-Hillsborough,Manchester Ward 12,President,,DEM,Ellinger,-
-Hillsborough,Mason,President,,DEM,Ellinger,-
-Hillsborough,Merrimack,President,,DEM,Ellinger,-
-Hillsborough,Milford,President,,DEM,Ellinger,-
-Hillsborough,Mont Vernon,President,,DEM,Ellinger,-
-Hillsborough,Nashua -Ward 1,President,,DEM,Ellinger,-
-Hillsborough,Nashua -Ward 2,President,,DEM,Ellinger,-
-Hillsborough,Nashua- Ward 3,President,,DEM,Ellinger,-
+Hillsborough,Manchester Ward 10,President,,DEM,Ellinger,
+Hillsborough,Manchester Ward 11,President,,DEM,Ellinger,
+Hillsborough,Manchester Ward 12,President,,DEM,Ellinger,
+Hillsborough,Mason,President,,DEM,Ellinger,
+Hillsborough,Merrimack,President,,DEM,Ellinger,
+Hillsborough,Milford,President,,DEM,Ellinger,
+Hillsborough,Mont Vernon,President,,DEM,Ellinger,
+Hillsborough,Nashua -Ward 1,President,,DEM,Ellinger,
+Hillsborough,Nashua -Ward 2,President,,DEM,Ellinger,
+Hillsborough,Nashua- Ward 3,President,,DEM,Ellinger,
 Hillsborough,Nashua -Ward 4,President,,DEM,Ellinger,1
-Hillsborough,Nashua -Ward 5,President,,DEM,Ellinger,-
-Hillsborough,Nashua -Ward 6,President,,DEM,Ellinger,-
-Hillsborough,Nashua -Ward 7,President,,DEM,Ellinger,-
-Hillsborough,Nashua- Ward 8,President,,DEM,Ellinger,-
-Hillsborough,Nashua -Ward 9,President,,DEM,Ellinger,-
-Hillsborough,New Boston,President,,DEM,Ellinger,-
-Hillsborough,New Ipswich,President,,DEM,Ellinger,-
+Hillsborough,Nashua -Ward 5,President,,DEM,Ellinger,
+Hillsborough,Nashua -Ward 6,President,,DEM,Ellinger,
+Hillsborough,Nashua -Ward 7,President,,DEM,Ellinger,
+Hillsborough,Nashua- Ward 8,President,,DEM,Ellinger,
+Hillsborough,Nashua -Ward 9,President,,DEM,Ellinger,
+Hillsborough,New Boston,President,,DEM,Ellinger,
+Hillsborough,New Ipswich,President,,DEM,Ellinger,
 Hillsborough,Pelham,President,,DEM,Ellinger,1
-Hillsborough,Peter-borough,President,,DEM,Ellinger,-
-Hillsborough,Sharon,President,,DEM,Ellinger,-
-Hillsborough,Temple,President,,DEM,Ellinger,-
-Hillsborough,Weare,President,,DEM,Ellinger,-
-Hillsborough,Wilton,President,,DEM,Ellinger,-
-Hillsborough,Windsor,President,,DEM,Ellinger,-
+Hillsborough,Peter-borough,President,,DEM,Ellinger,
+Hillsborough,Sharon,President,,DEM,Ellinger,
+Hillsborough,Temple,President,,DEM,Ellinger,
+Hillsborough,Weare,President,,DEM,Ellinger,
+Hillsborough,Wilton,President,,DEM,Ellinger,
+Hillsborough,Windsor,President,,DEM,Ellinger,
 Hillsborough,Amherst,President,,DEM,Tulsi Gabbard,106
 Hillsborough,Antrim,President,,DEM,Tulsi Gabbard,32
 Hillsborough,Bedford,President,,DEM,Tulsi Gabbard,161
@@ -5525,31 +5525,31 @@ Hillsborough,Manchester Ward 6,President,,DEM,Gleiberman,0
 Hillsborough,Manchester Ward 7,President,,DEM,Gleiberman,0
 Hillsborough,Manchester Ward 8,President,,DEM,Gleiberman,0
 Hillsborough,Manchester Ward 9,President,,DEM,Gleiberman,0
-Hillsborough,Manchester Ward 10,President,,DEM,Gleiberman,-
-Hillsborough,Manchester Ward 11,President,,DEM,Gleiberman,-
-Hillsborough,Manchester Ward 12,President,,DEM,Gleiberman,-
-Hillsborough,Mason,President,,DEM,Gleiberman,-
-Hillsborough,Merrimack,President,,DEM,Gleiberman,-
-Hillsborough,Milford,President,,DEM,Gleiberman,-
-Hillsborough,Mont Vernon,President,,DEM,Gleiberman,-
-Hillsborough,Nashua -Ward 1,President,,DEM,Gleiberman,-
-Hillsborough,Nashua -Ward 2,President,,DEM,Gleiberman,-
+Hillsborough,Manchester Ward 10,President,,DEM,Gleiberman,
+Hillsborough,Manchester Ward 11,President,,DEM,Gleiberman,
+Hillsborough,Manchester Ward 12,President,,DEM,Gleiberman,
+Hillsborough,Mason,President,,DEM,Gleiberman,
+Hillsborough,Merrimack,President,,DEM,Gleiberman,
+Hillsborough,Milford,President,,DEM,Gleiberman,
+Hillsborough,Mont Vernon,President,,DEM,Gleiberman,
+Hillsborough,Nashua -Ward 1,President,,DEM,Gleiberman,
+Hillsborough,Nashua -Ward 2,President,,DEM,Gleiberman,
 Hillsborough,Nashua- Ward 3,President,,DEM,Gleiberman,2
 Hillsborough,Nashua -Ward 4,President,,DEM,Gleiberman,2
-Hillsborough,Nashua -Ward 5,President,,DEM,Gleiberman,-
-Hillsborough,Nashua -Ward 6,President,,DEM,Gleiberman,-
-Hillsborough,Nashua -Ward 7,President,,DEM,Gleiberman,-
-Hillsborough,Nashua- Ward 8,President,,DEM,Gleiberman,-
-Hillsborough,Nashua -Ward 9,President,,DEM,Gleiberman,-
-Hillsborough,New Boston,President,,DEM,Gleiberman,-
-Hillsborough,New Ipswich,President,,DEM,Gleiberman,-
-Hillsborough,Pelham,President,,DEM,Gleiberman,-
-Hillsborough,Peter-borough,President,,DEM,Gleiberman,-
-Hillsborough,Sharon,President,,DEM,Gleiberman,-
-Hillsborough,Temple,President,,DEM,Gleiberman,-
-Hillsborough,Weare,President,,DEM,Gleiberman,-
-Hillsborough,Wilton,President,,DEM,Gleiberman,-
-Hillsborough,Windsor,President,,DEM,Gleiberman,-
+Hillsborough,Nashua -Ward 5,President,,DEM,Gleiberman,
+Hillsborough,Nashua -Ward 6,President,,DEM,Gleiberman,
+Hillsborough,Nashua -Ward 7,President,,DEM,Gleiberman,
+Hillsborough,Nashua- Ward 8,President,,DEM,Gleiberman,
+Hillsborough,Nashua -Ward 9,President,,DEM,Gleiberman,
+Hillsborough,New Boston,President,,DEM,Gleiberman,
+Hillsborough,New Ipswich,President,,DEM,Gleiberman,
+Hillsborough,Pelham,President,,DEM,Gleiberman,
+Hillsborough,Peter-borough,President,,DEM,Gleiberman,
+Hillsborough,Sharon,President,,DEM,Gleiberman,
+Hillsborough,Temple,President,,DEM,Gleiberman,
+Hillsborough,Weare,President,,DEM,Gleiberman,
+Hillsborough,Wilton,President,,DEM,Gleiberman,
+Hillsborough,Windsor,President,,DEM,Gleiberman,
 Hillsborough,Amherst,President,,DEM,Greenstein,1
 Hillsborough,Antrim,President,,DEM,Greenstein,0
 Hillsborough,Bedford,President,,DEM,Greenstein,0
@@ -5577,29 +5577,29 @@ Hillsborough,Manchester Ward 8,President,,DEM,Greenstein,0
 Hillsborough,Manchester Ward 9,President,,DEM,Greenstein,0
 Hillsborough,Manchester Ward 10,President,,DEM,Greenstein,1
 Hillsborough,Manchester Ward 11,President,,DEM,Greenstein,1
-Hillsborough,Manchester Ward 12,President,,DEM,Greenstein,-
-Hillsborough,Mason,President,,DEM,Greenstein,-
-Hillsborough,Merrimack,President,,DEM,Greenstein,-
-Hillsborough,Milford,President,,DEM,Greenstein,-
-Hillsborough,Mont Vernon,President,,DEM,Greenstein,-
+Hillsborough,Manchester Ward 12,President,,DEM,Greenstein,
+Hillsborough,Mason,President,,DEM,Greenstein,
+Hillsborough,Merrimack,President,,DEM,Greenstein,
+Hillsborough,Milford,President,,DEM,Greenstein,
+Hillsborough,Mont Vernon,President,,DEM,Greenstein,
 Hillsborough,Nashua -Ward 1,President,,DEM,Greenstein,1
 Hillsborough,Nashua -Ward 2,President,,DEM,Greenstein,1
-Hillsborough,Nashua- Ward 3,President,,DEM,Greenstein,-
-Hillsborough,Nashua -Ward 4,President,,DEM,Greenstein,-
-Hillsborough,Nashua -Ward 5,President,,DEM,Greenstein,-
-Hillsborough,Nashua -Ward 6,President,,DEM,Greenstein,-
+Hillsborough,Nashua- Ward 3,President,,DEM,Greenstein,
+Hillsborough,Nashua -Ward 4,President,,DEM,Greenstein,
+Hillsborough,Nashua -Ward 5,President,,DEM,Greenstein,
+Hillsborough,Nashua -Ward 6,President,,DEM,Greenstein,
 Hillsborough,Nashua -Ward 7,President,,DEM,Greenstein,1
 Hillsborough,Nashua- Ward 8,President,,DEM,Greenstein,1
-Hillsborough,Nashua -Ward 9,President,,DEM,Greenstein,-
-Hillsborough,New Boston,President,,DEM,Greenstein,-
-Hillsborough,New Ipswich,President,,DEM,Greenstein,-
+Hillsborough,Nashua -Ward 9,President,,DEM,Greenstein,
+Hillsborough,New Boston,President,,DEM,Greenstein,
+Hillsborough,New Ipswich,President,,DEM,Greenstein,
 Hillsborough,Pelham,President,,DEM,Greenstein,1
-Hillsborough,Peter-borough,President,,DEM,Greenstein,-
-Hillsborough,Sharon,President,,DEM,Greenstein,-
-Hillsborough,Temple,President,,DEM,Greenstein,-
-Hillsborough,Weare,President,,DEM,Greenstein,-
-Hillsborough,Wilton,President,,DEM,Greenstein,-
-Hillsborough,Windsor,President,,DEM,Greenstein,-
+Hillsborough,Peter-borough,President,,DEM,Greenstein,
+Hillsborough,Sharon,President,,DEM,Greenstein,
+Hillsborough,Temple,President,,DEM,Greenstein,
+Hillsborough,Weare,President,,DEM,Greenstein,
+Hillsborough,Wilton,President,,DEM,Greenstein,
+Hillsborough,Windsor,President,,DEM,Greenstein,
 Hillsborough,Amherst,President,,DEM,Kamala Harris,0
 Hillsborough,Antrim,President,,DEM,Kamala Harris,0
 Hillsborough,Bedford,President,,DEM,Kamala Harris,0
@@ -5625,31 +5625,31 @@ Hillsborough,Manchester Ward 6,President,,DEM,Kamala Harris,0
 Hillsborough,Manchester Ward 7,President,,DEM,Kamala Harris,1
 Hillsborough,Manchester Ward 8,President,,DEM,Kamala Harris,0
 Hillsborough,Manchester Ward 9,President,,DEM,Kamala Harris,22
-Hillsborough,Manchester Ward 10,President,,DEM,Kamala Harris,-
+Hillsborough,Manchester Ward 10,President,,DEM,Kamala Harris,
 Hillsborough,Manchester Ward 11,President,,DEM,Kamala Harris,1
-Hillsborough,Manchester Ward 12,President,,DEM,Kamala Harris,-
-Hillsborough,Mason,President,,DEM,Kamala Harris,-
+Hillsborough,Manchester Ward 12,President,,DEM,Kamala Harris,
+Hillsborough,Mason,President,,DEM,Kamala Harris,
 Hillsborough,Merrimack,President,,DEM,Kamala Harris,2
 Hillsborough,Milford,President,,DEM,Kamala Harris,2
-Hillsborough,Mont Vernon,President,,DEM,Kamala Harris,-
-Hillsborough,Nashua -Ward 1,President,,DEM,Kamala Harris,-
-Hillsborough,Nashua -Ward 2,President,,DEM,Kamala Harris,-
+Hillsborough,Mont Vernon,President,,DEM,Kamala Harris,
+Hillsborough,Nashua -Ward 1,President,,DEM,Kamala Harris,
+Hillsborough,Nashua -Ward 2,President,,DEM,Kamala Harris,
 Hillsborough,Nashua- Ward 3,President,,DEM,Kamala Harris,1
 Hillsborough,Nashua -Ward 4,President,,DEM,Kamala Harris,1
 Hillsborough,Nashua -Ward 5,President,,DEM,Kamala Harris,1
 Hillsborough,Nashua -Ward 6,President,,DEM,Kamala Harris,2
 Hillsborough,Nashua -Ward 7,President,,DEM,Kamala Harris,1
-Hillsborough,Nashua- Ward 8,President,,DEM,Kamala Harris,-
+Hillsborough,Nashua- Ward 8,President,,DEM,Kamala Harris,
 Hillsborough,Nashua -Ward 9,President,,DEM,Kamala Harris,1
 Hillsborough,New Boston,President,,DEM,Kamala Harris,1
-Hillsborough,New Ipswich,President,,DEM,Kamala Harris,-
+Hillsborough,New Ipswich,President,,DEM,Kamala Harris,
 Hillsborough,Pelham,President,,DEM,Kamala Harris,2
 Hillsborough,Peter-borough,President,,DEM,Kamala Harris,1
-Hillsborough,Sharon,President,,DEM,Kamala Harris,-
-Hillsborough,Temple,President,,DEM,Kamala Harris,-
+Hillsborough,Sharon,President,,DEM,Kamala Harris,
+Hillsborough,Temple,President,,DEM,Kamala Harris,
 Hillsborough,Weare,President,,DEM,Kamala Harris,1
-Hillsborough,Wilton,President,,DEM,Kamala Harris,-
-Hillsborough,Windsor,President,,DEM,Kamala Harris,-
+Hillsborough,Wilton,President,,DEM,Kamala Harris,
+Hillsborough,Windsor,President,,DEM,Kamala Harris,
 Hillsborough,Amherst,President,,DEM,Hewes,0
 Hillsborough,Antrim,President,,DEM,Hewes,0
 Hillsborough,Bedford,President,,DEM,Hewes,0
@@ -5675,31 +5675,31 @@ Hillsborough,Manchester Ward 6,President,,DEM,Hewes,1
 Hillsborough,Manchester Ward 7,President,,DEM,Hewes,0
 Hillsborough,Manchester Ward 8,President,,DEM,Hewes,0
 Hillsborough,Manchester Ward 9,President,,DEM,Hewes,0
-Hillsborough,Manchester Ward 10,President,,DEM,Hewes,-
-Hillsborough,Manchester Ward 11,President,,DEM,Hewes,-
-Hillsborough,Manchester Ward 12,President,,DEM,Hewes,-
-Hillsborough,Mason,President,,DEM,Hewes,-
-Hillsborough,Merrimack,President,,DEM,Hewes,-
-Hillsborough,Milford,President,,DEM,Hewes,-
-Hillsborough,Mont Vernon,President,,DEM,Hewes,-
-Hillsborough,Nashua -Ward 1,President,,DEM,Hewes,-
+Hillsborough,Manchester Ward 10,President,,DEM,Hewes,
+Hillsborough,Manchester Ward 11,President,,DEM,Hewes,
+Hillsborough,Manchester Ward 12,President,,DEM,Hewes,
+Hillsborough,Mason,President,,DEM,Hewes,
+Hillsborough,Merrimack,President,,DEM,Hewes,
+Hillsborough,Milford,President,,DEM,Hewes,
+Hillsborough,Mont Vernon,President,,DEM,Hewes,
+Hillsborough,Nashua -Ward 1,President,,DEM,Hewes,
 Hillsborough,Nashua -Ward 2,President,,DEM,Hewes,1
 Hillsborough,Nashua- Ward 3,President,,DEM,Hewes,1
-Hillsborough,Nashua -Ward 4,President,,DEM,Hewes,-
-Hillsborough,Nashua -Ward 5,President,,DEM,Hewes,-
-Hillsborough,Nashua -Ward 6,President,,DEM,Hewes,-
-Hillsborough,Nashua -Ward 7,President,,DEM,Hewes,-
-Hillsborough,Nashua- Ward 8,President,,DEM,Hewes,-
-Hillsborough,Nashua -Ward 9,President,,DEM,Hewes,-
-Hillsborough,New Boston,President,,DEM,Hewes,-
-Hillsborough,New Ipswich,President,,DEM,Hewes,-
+Hillsborough,Nashua -Ward 4,President,,DEM,Hewes,
+Hillsborough,Nashua -Ward 5,President,,DEM,Hewes,
+Hillsborough,Nashua -Ward 6,President,,DEM,Hewes,
+Hillsborough,Nashua -Ward 7,President,,DEM,Hewes,
+Hillsborough,Nashua- Ward 8,President,,DEM,Hewes,
+Hillsborough,Nashua -Ward 9,President,,DEM,Hewes,
+Hillsborough,New Boston,President,,DEM,Hewes,
+Hillsborough,New Ipswich,President,,DEM,Hewes,
 Hillsborough,Pelham,President,,DEM,Hewes,1
-Hillsborough,Peter-borough,President,,DEM,Hewes,-
-Hillsborough,Sharon,President,,DEM,Hewes,-
-Hillsborough,Temple,President,,DEM,Hewes,-
-Hillsborough,Weare,President,,DEM,Hewes,-
-Hillsborough,Wilton,President,,DEM,Hewes,-
-Hillsborough,Windsor,President,,DEM,Hewes,-
+Hillsborough,Peter-borough,President,,DEM,Hewes,
+Hillsborough,Sharon,President,,DEM,Hewes,
+Hillsborough,Temple,President,,DEM,Hewes,
+Hillsborough,Weare,President,,DEM,Hewes,
+Hillsborough,Wilton,President,,DEM,Hewes,
+Hillsborough,Windsor,President,,DEM,Hewes,
 Hillsborough,Amherst,President,,DEM,Amy Klobuchar,893
 Hillsborough,Antrim,President,,DEM,Amy Klobuchar,105
 Hillsborough,Bedford,President,,DEM,Amy Klobuchar,1385
@@ -5775,31 +5775,31 @@ Hillsborough,Manchester Ward 6,President,,DEM,Koos,0
 Hillsborough,Manchester Ward 7,President,,DEM,Koos,0
 Hillsborough,Manchester Ward 8,President,,DEM,Koos,1
 Hillsborough,Manchester Ward 9,President,,DEM,Koos,1
-Hillsborough,Manchester Ward 10,President,,DEM,Koos,-
-Hillsborough,Manchester Ward 11,President,,DEM,Koos,-
+Hillsborough,Manchester Ward 10,President,,DEM,Koos,
+Hillsborough,Manchester Ward 11,President,,DEM,Koos,
 Hillsborough,Manchester Ward 12,President,,DEM,Koos,1
-Hillsborough,Mason,President,,DEM,Koos,-
+Hillsborough,Mason,President,,DEM,Koos,
 Hillsborough,Merrimack,President,,DEM,Koos,1
 Hillsborough,Milford,President,,DEM,Koos,1
-Hillsborough,Mont Vernon,President,,DEM,Koos,-
-Hillsborough,Nashua -Ward 1,President,,DEM,Koos,-
-Hillsborough,Nashua -Ward 2,President,,DEM,Koos,-
-Hillsborough,Nashua- Ward 3,President,,DEM,Koos,-
+Hillsborough,Mont Vernon,President,,DEM,Koos,
+Hillsborough,Nashua -Ward 1,President,,DEM,Koos,
+Hillsborough,Nashua -Ward 2,President,,DEM,Koos,
+Hillsborough,Nashua- Ward 3,President,,DEM,Koos,
 Hillsborough,Nashua -Ward 4,President,,DEM,Koos,2
 Hillsborough,Nashua -Ward 5,President,,DEM,Koos,1
 Hillsborough,Nashua -Ward 6,President,,DEM,Koos,1
-Hillsborough,Nashua -Ward 7,President,,DEM,Koos,-
-Hillsborough,Nashua- Ward 8,President,,DEM,Koos,-
+Hillsborough,Nashua -Ward 7,President,,DEM,Koos,
+Hillsborough,Nashua- Ward 8,President,,DEM,Koos,
 Hillsborough,Nashua -Ward 9,President,,DEM,Koos,1
-Hillsborough,New Boston,President,,DEM,Koos,-
-Hillsborough,New Ipswich,President,,DEM,Koos,-
+Hillsborough,New Boston,President,,DEM,Koos,
+Hillsborough,New Ipswich,President,,DEM,Koos,
 Hillsborough,Pelham,President,,DEM,Koos,1
-Hillsborough,Peter-borough,President,,DEM,Koos,-
-Hillsborough,Sharon,President,,DEM,Koos,-
-Hillsborough,Temple,President,,DEM,Koos,-
-Hillsborough,Weare,President,,DEM,Koos,-
-Hillsborough,Wilton,President,,DEM,Koos,-
-Hillsborough,Windsor,President,,DEM,Koos,-
+Hillsborough,Peter-borough,President,,DEM,Koos,
+Hillsborough,Sharon,President,,DEM,Koos,
+Hillsborough,Temple,President,,DEM,Koos,
+Hillsborough,Weare,President,,DEM,Koos,
+Hillsborough,Wilton,President,,DEM,Koos,
+Hillsborough,Windsor,President,,DEM,Koos,
 Hillsborough,Amherst,President,,DEM,Kraus,0
 Hillsborough,Antrim,President,,DEM,Kraus,0
 Hillsborough,Bedford,President,,DEM,Kraus,1
@@ -5826,30 +5826,30 @@ Hillsborough,Manchester Ward 7,President,,DEM,Kraus,0
 Hillsborough,Manchester Ward 8,President,,DEM,Kraus,1
 Hillsborough,Manchester Ward 9,President,,DEM,Kraus,1
 Hillsborough,Manchester Ward 10,President,,DEM,Kraus,1
-Hillsborough,Manchester Ward 11,President,,DEM,Kraus,-
-Hillsborough,Manchester Ward 12,President,,DEM,Kraus,-
-Hillsborough,Mason,President,,DEM,Kraus,-
+Hillsborough,Manchester Ward 11,President,,DEM,Kraus,
+Hillsborough,Manchester Ward 12,President,,DEM,Kraus,
+Hillsborough,Mason,President,,DEM,Kraus,
 Hillsborough,Merrimack,President,,DEM,Kraus,32
 Hillsborough,Milford,President,,DEM,Kraus,1
-Hillsborough,Mont Vernon,President,,DEM,Kraus,-
-Hillsborough,Nashua -Ward 1,President,,DEM,Kraus,-
+Hillsborough,Mont Vernon,President,,DEM,Kraus,
+Hillsborough,Nashua -Ward 1,President,,DEM,Kraus,
 Hillsborough,Nashua -Ward 2,President,,DEM,Kraus,1
-Hillsborough,Nashua- Ward 3,President,,DEM,Kraus,-
-Hillsborough,Nashua -Ward 4,President,,DEM,Kraus,-
-Hillsborough,Nashua -Ward 5,President,,DEM,Kraus,-
+Hillsborough,Nashua- Ward 3,President,,DEM,Kraus,
+Hillsborough,Nashua -Ward 4,President,,DEM,Kraus,
+Hillsborough,Nashua -Ward 5,President,,DEM,Kraus,
 Hillsborough,Nashua -Ward 6,President,,DEM,Kraus,1
-Hillsborough,Nashua -Ward 7,President,,DEM,Kraus,-
-Hillsborough,Nashua- Ward 8,President,,DEM,Kraus,-
-Hillsborough,Nashua -Ward 9,President,,DEM,Kraus,-
-Hillsborough,New Boston,President,,DEM,Kraus,-
-Hillsborough,New Ipswich,President,,DEM,Kraus,-
+Hillsborough,Nashua -Ward 7,President,,DEM,Kraus,
+Hillsborough,Nashua- Ward 8,President,,DEM,Kraus,
+Hillsborough,Nashua -Ward 9,President,,DEM,Kraus,
+Hillsborough,New Boston,President,,DEM,Kraus,
+Hillsborough,New Ipswich,President,,DEM,Kraus,
 Hillsborough,Pelham,President,,DEM,Kraus,1
-Hillsborough,Peter-borough,President,,DEM,Kraus,-
-Hillsborough,Sharon,President,,DEM,Kraus,-
-Hillsborough,Temple,President,,DEM,Kraus,-
-Hillsborough,Weare,President,,DEM,Kraus,-
-Hillsborough,Wilton,President,,DEM,Kraus,-
-Hillsborough,Windsor,President,,DEM,Kraus,-
+Hillsborough,Peter-borough,President,,DEM,Kraus,
+Hillsborough,Sharon,President,,DEM,Kraus,
+Hillsborough,Temple,President,,DEM,Kraus,
+Hillsborough,Weare,President,,DEM,Kraus,
+Hillsborough,Wilton,President,,DEM,Kraus,
+Hillsborough,Windsor,President,,DEM,Kraus,
 Hillsborough,Amherst,President,,DEM,Krichevsky,0
 Hillsborough,Antrim,President,,DEM,Krichevsky,0
 Hillsborough,Bedford,President,,DEM,Krichevsky,0
@@ -5875,31 +5875,31 @@ Hillsborough,Manchester Ward 6,President,,DEM,Krichevsky,1
 Hillsborough,Manchester Ward 7,President,,DEM,Krichevsky,0
 Hillsborough,Manchester Ward 8,President,,DEM,Krichevsky,0
 Hillsborough,Manchester Ward 9,President,,DEM,Krichevsky,0
-Hillsborough,Manchester Ward 10,President,,DEM,Krichevsky,-
+Hillsborough,Manchester Ward 10,President,,DEM,Krichevsky,
 Hillsborough,Manchester Ward 11,President,,DEM,Krichevsky,1
-Hillsborough,Manchester Ward 12,President,,DEM,Krichevsky,-
-Hillsborough,Mason,President,,DEM,Krichevsky,-
-Hillsborough,Merrimack,President,,DEM,Krichevsky,-
-Hillsborough,Milford,President,,DEM,Krichevsky,-
-Hillsborough,Mont Vernon,President,,DEM,Krichevsky,-
-Hillsborough,Nashua -Ward 1,President,,DEM,Krichevsky,-
-Hillsborough,Nashua -Ward 2,President,,DEM,Krichevsky,-
-Hillsborough,Nashua- Ward 3,President,,DEM,Krichevsky,-
-Hillsborough,Nashua -Ward 4,President,,DEM,Krichevsky,-
-Hillsborough,Nashua -Ward 5,President,,DEM,Krichevsky,-
-Hillsborough,Nashua -Ward 6,President,,DEM,Krichevsky,-
-Hillsborough,Nashua -Ward 7,President,,DEM,Krichevsky,-
+Hillsborough,Manchester Ward 12,President,,DEM,Krichevsky,
+Hillsborough,Mason,President,,DEM,Krichevsky,
+Hillsborough,Merrimack,President,,DEM,Krichevsky,
+Hillsborough,Milford,President,,DEM,Krichevsky,
+Hillsborough,Mont Vernon,President,,DEM,Krichevsky,
+Hillsborough,Nashua -Ward 1,President,,DEM,Krichevsky,
+Hillsborough,Nashua -Ward 2,President,,DEM,Krichevsky,
+Hillsborough,Nashua- Ward 3,President,,DEM,Krichevsky,
+Hillsborough,Nashua -Ward 4,President,,DEM,Krichevsky,
+Hillsborough,Nashua -Ward 5,President,,DEM,Krichevsky,
+Hillsborough,Nashua -Ward 6,President,,DEM,Krichevsky,
+Hillsborough,Nashua -Ward 7,President,,DEM,Krichevsky,
 Hillsborough,Nashua- Ward 8,President,,DEM,Krichevsky,2
-Hillsborough,Nashua -Ward 9,President,,DEM,Krichevsky,-
-Hillsborough,New Boston,President,,DEM,Krichevsky,-
-Hillsborough,New Ipswich,President,,DEM,Krichevsky,-
-Hillsborough,Pelham,President,,DEM,Krichevsky,-
-Hillsborough,Peter-borough,President,,DEM,Krichevsky,-
-Hillsborough,Sharon,President,,DEM,Krichevsky,-
-Hillsborough,Temple,President,,DEM,Krichevsky,-
-Hillsborough,Weare,President,,DEM,Krichevsky,-
-Hillsborough,Wilton,President,,DEM,Krichevsky,-
-Hillsborough,Windsor,President,,DEM,Krichevsky,-
+Hillsborough,Nashua -Ward 9,President,,DEM,Krichevsky,
+Hillsborough,New Boston,President,,DEM,Krichevsky,
+Hillsborough,New Ipswich,President,,DEM,Krichevsky,
+Hillsborough,Pelham,President,,DEM,Krichevsky,
+Hillsborough,Peter-borough,President,,DEM,Krichevsky,
+Hillsborough,Sharon,President,,DEM,Krichevsky,
+Hillsborough,Temple,President,,DEM,Krichevsky,
+Hillsborough,Weare,President,,DEM,Krichevsky,
+Hillsborough,Wilton,President,,DEM,Krichevsky,
+Hillsborough,Windsor,President,,DEM,Krichevsky,
 Hillsborough,Amherst,President,,DEM,Moroz,1
 Hillsborough,Antrim,President,,DEM,Moroz,0
 Hillsborough,Bedford,President,,DEM,Moroz,0
@@ -5925,31 +5925,31 @@ Hillsborough,Manchester Ward 6,President,,DEM,Moroz,1
 Hillsborough,Manchester Ward 7,President,,DEM,Moroz,0
 Hillsborough,Manchester Ward 8,President,,DEM,Moroz,0
 Hillsborough,Manchester Ward 9,President,,DEM,Moroz,0
-Hillsborough,Manchester Ward 10,President,,DEM,Moroz,-
+Hillsborough,Manchester Ward 10,President,,DEM,Moroz,
 Hillsborough,Manchester Ward 11,President,,DEM,Moroz,1
-Hillsborough,Manchester Ward 12,President,,DEM,Moroz,-
-Hillsborough,Mason,President,,DEM,Moroz,-
+Hillsborough,Manchester Ward 12,President,,DEM,Moroz,
+Hillsborough,Mason,President,,DEM,Moroz,
 Hillsborough,Merrimack,President,,DEM,Moroz,1
-Hillsborough,Milford,President,,DEM,Moroz,-
-Hillsborough,Mont Vernon,President,,DEM,Moroz,-
-Hillsborough,Nashua -Ward 1,President,,DEM,Moroz,-
-Hillsborough,Nashua -Ward 2,President,,DEM,Moroz,-
-Hillsborough,Nashua- Ward 3,President,,DEM,Moroz,-
-Hillsborough,Nashua -Ward 4,President,,DEM,Moroz,-
-Hillsborough,Nashua -Ward 5,President,,DEM,Moroz,-
-Hillsborough,Nashua -Ward 6,President,,DEM,Moroz,-
-Hillsborough,Nashua -Ward 7,President,,DEM,Moroz,-
-Hillsborough,Nashua- Ward 8,President,,DEM,Moroz,-
-Hillsborough,Nashua -Ward 9,President,,DEM,Moroz,-
-Hillsborough,New Boston,President,,DEM,Moroz,-
-Hillsborough,New Ipswich,President,,DEM,Moroz,-
-Hillsborough,Pelham,President,,DEM,Moroz,-
-Hillsborough,Peter-borough,President,,DEM,Moroz,-
-Hillsborough,Sharon,President,,DEM,Moroz,-
-Hillsborough,Temple,President,,DEM,Moroz,-
-Hillsborough,Weare,President,,DEM,Moroz,-
-Hillsborough,Wilton,President,,DEM,Moroz,-
-Hillsborough,Windsor,President,,DEM,Moroz,-
+Hillsborough,Milford,President,,DEM,Moroz,
+Hillsborough,Mont Vernon,President,,DEM,Moroz,
+Hillsborough,Nashua -Ward 1,President,,DEM,Moroz,
+Hillsborough,Nashua -Ward 2,President,,DEM,Moroz,
+Hillsborough,Nashua- Ward 3,President,,DEM,Moroz,
+Hillsborough,Nashua -Ward 4,President,,DEM,Moroz,
+Hillsborough,Nashua -Ward 5,President,,DEM,Moroz,
+Hillsborough,Nashua -Ward 6,President,,DEM,Moroz,
+Hillsborough,Nashua -Ward 7,President,,DEM,Moroz,
+Hillsborough,Nashua- Ward 8,President,,DEM,Moroz,
+Hillsborough,Nashua -Ward 9,President,,DEM,Moroz,
+Hillsborough,New Boston,President,,DEM,Moroz,
+Hillsborough,New Ipswich,President,,DEM,Moroz,
+Hillsborough,Pelham,President,,DEM,Moroz,
+Hillsborough,Peter-borough,President,,DEM,Moroz,
+Hillsborough,Sharon,President,,DEM,Moroz,
+Hillsborough,Temple,President,,DEM,Moroz,
+Hillsborough,Weare,President,,DEM,Moroz,
+Hillsborough,Wilton,President,,DEM,Moroz,
+Hillsborough,Windsor,President,,DEM,Moroz,
 Hillsborough,Amherst,President,,DEM,Deval Patrick,11
 Hillsborough,Antrim,President,,DEM,Deval Patrick,0
 Hillsborough,Bedford,President,,DEM,Deval Patrick,22
@@ -5995,11 +5995,11 @@ Hillsborough,New Boston,President,,DEM,Deval Patrick,9
 Hillsborough,New Ipswich,President,,DEM,Deval Patrick,3
 Hillsborough,Pelham,President,,DEM,Deval Patrick,15
 Hillsborough,Peter-borough,President,,DEM,Deval Patrick,10
-Hillsborough,Sharon,President,,DEM,Deval Patrick,-
+Hillsborough,Sharon,President,,DEM,Deval Patrick,
 Hillsborough,Temple,President,,DEM,Deval Patrick,4
 Hillsborough,Weare,President,,DEM,Deval Patrick,2
 Hillsborough,Wilton,President,,DEM,Deval Patrick,3
-Hillsborough,Windsor,President,,DEM,Deval Patrick,-
+Hillsborough,Windsor,President,,DEM,Deval Patrick,
 Hillsborough,Amherst,President,,DEM,Bernie Sanders,589
 Hillsborough,Antrim,President,,DEM,Bernie Sanders,186
 Hillsborough,Bedford,President,,DEM,Bernie Sanders,830
@@ -6076,30 +6076,30 @@ Hillsborough,Manchester Ward 7,President,,DEM,Joe Sestak,2
 Hillsborough,Manchester Ward 8,President,,DEM,Joe Sestak,1
 Hillsborough,Manchester Ward 9,President,,DEM,Joe Sestak,3
 Hillsborough,Manchester Ward 10,President,,DEM,Joe Sestak,1
-Hillsborough,Manchester Ward 11,President,,DEM,Joe Sestak,-
-Hillsborough,Manchester Ward 12,President,,DEM,Joe Sestak,-
+Hillsborough,Manchester Ward 11,President,,DEM,Joe Sestak,
+Hillsborough,Manchester Ward 12,President,,DEM,Joe Sestak,
 Hillsborough,Mason,President,,DEM,Joe Sestak,1
-Hillsborough,Merrimack,President,,DEM,Joe Sestak,-
+Hillsborough,Merrimack,President,,DEM,Joe Sestak,
 Hillsborough,Milford,President,,DEM,Joe Sestak,3
-Hillsborough,Mont Vernon,President,,DEM,Joe Sestak,-
+Hillsborough,Mont Vernon,President,,DEM,Joe Sestak,
 Hillsborough,Nashua -Ward 1,President,,DEM,Joe Sestak,4
-Hillsborough,Nashua -Ward 2,President,,DEM,Joe Sestak,-
-Hillsborough,Nashua- Ward 3,President,,DEM,Joe Sestak,-
-Hillsborough,Nashua -Ward 4,President,,DEM,Joe Sestak,-
-Hillsborough,Nashua -Ward 5,President,,DEM,Joe Sestak,-
+Hillsborough,Nashua -Ward 2,President,,DEM,Joe Sestak,
+Hillsborough,Nashua- Ward 3,President,,DEM,Joe Sestak,
+Hillsborough,Nashua -Ward 4,President,,DEM,Joe Sestak,
+Hillsborough,Nashua -Ward 5,President,,DEM,Joe Sestak,
 Hillsborough,Nashua -Ward 6,President,,DEM,Joe Sestak,2
 Hillsborough,Nashua -Ward 7,President,,DEM,Joe Sestak,1
-Hillsborough,Nashua- Ward 8,President,,DEM,Joe Sestak,-
-Hillsborough,Nashua -Ward 9,President,,DEM,Joe Sestak,-
+Hillsborough,Nashua- Ward 8,President,,DEM,Joe Sestak,
+Hillsborough,Nashua -Ward 9,President,,DEM,Joe Sestak,
 Hillsborough,New Boston,President,,DEM,Joe Sestak,1
-Hillsborough,New Ipswich,President,,DEM,Joe Sestak,-
+Hillsborough,New Ipswich,President,,DEM,Joe Sestak,
 Hillsborough,Pelham,President,,DEM,Joe Sestak,1
 Hillsborough,Peter-borough,President,,DEM,Joe Sestak,2
-Hillsborough,Sharon,President,,DEM,Joe Sestak,-
-Hillsborough,Temple,President,,DEM,Joe Sestak,-
-Hillsborough,Weare,President,,DEM,Joe Sestak,-
-Hillsborough,Wilton,President,,DEM,Joe Sestak,-
-Hillsborough,Windsor,President,,DEM,Joe Sestak,-
+Hillsborough,Sharon,President,,DEM,Joe Sestak,
+Hillsborough,Temple,President,,DEM,Joe Sestak,
+Hillsborough,Weare,President,,DEM,Joe Sestak,
+Hillsborough,Wilton,President,,DEM,Joe Sestak,
+Hillsborough,Windsor,President,,DEM,Joe Sestak,
 Hillsborough,Amherst,President,,DEM,Sloan,0
 Hillsborough,Antrim,President,,DEM,Sloan,0
 Hillsborough,Bedford,President,,DEM,Sloan,1
@@ -6126,30 +6126,30 @@ Hillsborough,Manchester Ward 7,President,,DEM,Sloan,0
 Hillsborough,Manchester Ward 8,President,,DEM,Sloan,0
 Hillsborough,Manchester Ward 9,President,,DEM,Sloan,0
 Hillsborough,Manchester Ward 10,President,,DEM,Sloan,1
-Hillsborough,Manchester Ward 11,President,,DEM,Sloan,-
-Hillsborough,Manchester Ward 12,President,,DEM,Sloan,-
-Hillsborough,Mason,President,,DEM,Sloan,-
-Hillsborough,Merrimack,President,,DEM,Sloan,-
+Hillsborough,Manchester Ward 11,President,,DEM,Sloan,
+Hillsborough,Manchester Ward 12,President,,DEM,Sloan,
+Hillsborough,Mason,President,,DEM,Sloan,
+Hillsborough,Merrimack,President,,DEM,Sloan,
 Hillsborough,Milford,President,,DEM,Sloan,1
-Hillsborough,Mont Vernon,President,,DEM,Sloan,-
+Hillsborough,Mont Vernon,President,,DEM,Sloan,
 Hillsborough,Nashua -Ward 1,President,,DEM,Sloan,1
 Hillsborough,Nashua -Ward 2,President,,DEM,Sloan,1
-Hillsborough,Nashua- Ward 3,President,,DEM,Sloan,-
-Hillsborough,Nashua -Ward 4,President,,DEM,Sloan,-
-Hillsborough,Nashua -Ward 5,President,,DEM,Sloan,-
+Hillsborough,Nashua- Ward 3,President,,DEM,Sloan,
+Hillsborough,Nashua -Ward 4,President,,DEM,Sloan,
+Hillsborough,Nashua -Ward 5,President,,DEM,Sloan,
 Hillsborough,Nashua -Ward 6,President,,DEM,Sloan,1
-Hillsborough,Nashua -Ward 7,President,,DEM,Sloan,-
-Hillsborough,Nashua- Ward 8,President,,DEM,Sloan,-
-Hillsborough,Nashua -Ward 9,President,,DEM,Sloan,-
-Hillsborough,New Boston,President,,DEM,Sloan,-
-Hillsborough,New Ipswich,President,,DEM,Sloan,-
-Hillsborough,Pelham,President,,DEM,Sloan,-
-Hillsborough,Peter-borough,President,,DEM,Sloan,-
-Hillsborough,Sharon,President,,DEM,Sloan,-
-Hillsborough,Temple,President,,DEM,Sloan,-
+Hillsborough,Nashua -Ward 7,President,,DEM,Sloan,
+Hillsborough,Nashua- Ward 8,President,,DEM,Sloan,
+Hillsborough,Nashua -Ward 9,President,,DEM,Sloan,
+Hillsborough,New Boston,President,,DEM,Sloan,
+Hillsborough,New Ipswich,President,,DEM,Sloan,
+Hillsborough,Pelham,President,,DEM,Sloan,
+Hillsborough,Peter-borough,President,,DEM,Sloan,
+Hillsborough,Sharon,President,,DEM,Sloan,
+Hillsborough,Temple,President,,DEM,Sloan,
 Hillsborough,Weare,President,,DEM,Sloan,2
-Hillsborough,Wilton,President,,DEM,Sloan,-
-Hillsborough,Windsor,President,,DEM,Sloan,-
+Hillsborough,Wilton,President,,DEM,Sloan,
+Hillsborough,Windsor,President,,DEM,Sloan,
 Hillsborough,Amherst,President,,DEM,Tom Steyer,82
 Hillsborough,Antrim,President,,DEM,Tom Steyer,23
 Hillsborough,Bedford,President,,DEM,Tom Steyer,166
@@ -6226,30 +6226,30 @@ Hillsborough,Manchester Ward 7,President,,DEM,Thistle,0
 Hillsborough,Manchester Ward 8,President,,DEM,Thistle,0
 Hillsborough,Manchester Ward 9,President,,DEM,Thistle,0
 Hillsborough,Manchester Ward 10,President,,DEM,Thistle,1
-Hillsborough,Manchester Ward 11,President,,DEM,Thistle,-
-Hillsborough,Manchester Ward 12,President,,DEM,Thistle,-
-Hillsborough,Mason,President,,DEM,Thistle,-
+Hillsborough,Manchester Ward 11,President,,DEM,Thistle,
+Hillsborough,Manchester Ward 12,President,,DEM,Thistle,
+Hillsborough,Mason,President,,DEM,Thistle,
 Hillsborough,Merrimack,President,,DEM,Thistle,1
 Hillsborough,Milford,President,,DEM,Thistle,1
-Hillsborough,Mont Vernon,President,,DEM,Thistle,-
+Hillsborough,Mont Vernon,President,,DEM,Thistle,
 Hillsborough,Nashua -Ward 1,President,,DEM,Thistle,1
-Hillsborough,Nashua -Ward 2,President,,DEM,Thistle,-
-Hillsborough,Nashua- Ward 3,President,,DEM,Thistle,-
-Hillsborough,Nashua -Ward 4,President,,DEM,Thistle,-
-Hillsborough,Nashua -Ward 5,President,,DEM,Thistle,-
-Hillsborough,Nashua -Ward 6,President,,DEM,Thistle,-
-Hillsborough,Nashua -Ward 7,President,,DEM,Thistle,-
-Hillsborough,Nashua- Ward 8,President,,DEM,Thistle,-
-Hillsborough,Nashua -Ward 9,President,,DEM,Thistle,-
-Hillsborough,New Boston,President,,DEM,Thistle,-
-Hillsborough,New Ipswich,President,,DEM,Thistle,-
+Hillsborough,Nashua -Ward 2,President,,DEM,Thistle,
+Hillsborough,Nashua- Ward 3,President,,DEM,Thistle,
+Hillsborough,Nashua -Ward 4,President,,DEM,Thistle,
+Hillsborough,Nashua -Ward 5,President,,DEM,Thistle,
+Hillsborough,Nashua -Ward 6,President,,DEM,Thistle,
+Hillsborough,Nashua -Ward 7,President,,DEM,Thistle,
+Hillsborough,Nashua- Ward 8,President,,DEM,Thistle,
+Hillsborough,Nashua -Ward 9,President,,DEM,Thistle,
+Hillsborough,New Boston,President,,DEM,Thistle,
+Hillsborough,New Ipswich,President,,DEM,Thistle,
 Hillsborough,Pelham,President,,DEM,Thistle,1
-Hillsborough,Peter-borough,President,,DEM,Thistle,-
-Hillsborough,Sharon,President,,DEM,Thistle,-
+Hillsborough,Peter-borough,President,,DEM,Thistle,
+Hillsborough,Sharon,President,,DEM,Thistle,
 Hillsborough,Temple,President,,DEM,Thistle,1
 Hillsborough,Weare,President,,DEM,Thistle,1
-Hillsborough,Wilton,President,,DEM,Thistle,-
-Hillsborough,Windsor,President,,DEM,Thistle,-
+Hillsborough,Wilton,President,,DEM,Thistle,
+Hillsborough,Windsor,President,,DEM,Thistle,
 Hillsborough,Amherst,President,,DEM,Torgesen,0
 Hillsborough,Antrim,President,,DEM,Torgesen,0
 Hillsborough,Bedford,President,,DEM,Torgesen,0
@@ -6275,31 +6275,31 @@ Hillsborough,Manchester Ward 6,President,,DEM,Torgesen,0
 Hillsborough,Manchester Ward 7,President,,DEM,Torgesen,0
 Hillsborough,Manchester Ward 8,President,,DEM,Torgesen,0
 Hillsborough,Manchester Ward 9,President,,DEM,Torgesen,0
-Hillsborough,Manchester Ward 10,President,,DEM,Torgesen,-
-Hillsborough,Manchester Ward 11,President,,DEM,Torgesen,-
-Hillsborough,Manchester Ward 12,President,,DEM,Torgesen,-
-Hillsborough,Mason,President,,DEM,Torgesen,-
-Hillsborough,Merrimack,President,,DEM,Torgesen,-
-Hillsborough,Milford,President,,DEM,Torgesen,-
-Hillsborough,Mont Vernon,President,,DEM,Torgesen,-
-Hillsborough,Nashua -Ward 1,President,,DEM,Torgesen,-
-Hillsborough,Nashua -Ward 2,President,,DEM,Torgesen,-
+Hillsborough,Manchester Ward 10,President,,DEM,Torgesen,
+Hillsborough,Manchester Ward 11,President,,DEM,Torgesen,
+Hillsborough,Manchester Ward 12,President,,DEM,Torgesen,
+Hillsborough,Mason,President,,DEM,Torgesen,
+Hillsborough,Merrimack,President,,DEM,Torgesen,
+Hillsborough,Milford,President,,DEM,Torgesen,
+Hillsborough,Mont Vernon,President,,DEM,Torgesen,
+Hillsborough,Nashua -Ward 1,President,,DEM,Torgesen,
+Hillsborough,Nashua -Ward 2,President,,DEM,Torgesen,
 Hillsborough,Nashua- Ward 3,President,,DEM,Torgesen,1
-Hillsborough,Nashua -Ward 4,President,,DEM,Torgesen,-
-Hillsborough,Nashua -Ward 5,President,,DEM,Torgesen,-
-Hillsborough,Nashua -Ward 6,President,,DEM,Torgesen,-
+Hillsborough,Nashua -Ward 4,President,,DEM,Torgesen,
+Hillsborough,Nashua -Ward 5,President,,DEM,Torgesen,
+Hillsborough,Nashua -Ward 6,President,,DEM,Torgesen,
 Hillsborough,Nashua -Ward 7,President,,DEM,Torgesen,1
-Hillsborough,Nashua- Ward 8,President,,DEM,Torgesen,-
-Hillsborough,Nashua -Ward 9,President,,DEM,Torgesen,-
-Hillsborough,New Boston,President,,DEM,Torgesen,-
-Hillsborough,New Ipswich,President,,DEM,Torgesen,-
+Hillsborough,Nashua- Ward 8,President,,DEM,Torgesen,
+Hillsborough,Nashua -Ward 9,President,,DEM,Torgesen,
+Hillsborough,New Boston,President,,DEM,Torgesen,
+Hillsborough,New Ipswich,President,,DEM,Torgesen,
 Hillsborough,Pelham,President,,DEM,Torgesen,1
-Hillsborough,Peter-borough,President,,DEM,Torgesen,-
-Hillsborough,Sharon,President,,DEM,Torgesen,-
-Hillsborough,Temple,President,,DEM,Torgesen,-
-Hillsborough,Weare,President,,DEM,Torgesen,-
-Hillsborough,Wilton,President,,DEM,Torgesen,-
-Hillsborough,Windsor,President,,DEM,Torgesen,-
+Hillsborough,Peter-borough,President,,DEM,Torgesen,
+Hillsborough,Sharon,President,,DEM,Torgesen,
+Hillsborough,Temple,President,,DEM,Torgesen,
+Hillsborough,Weare,President,,DEM,Torgesen,
+Hillsborough,Wilton,President,,DEM,Torgesen,
+Hillsborough,Windsor,President,,DEM,Torgesen,
 Hillsborough,Amherst,President,,DEM,Elizabeth Warren,306
 Hillsborough,Antrim,President,,DEM,Elizabeth Warren,62
 Hillsborough,Bedford,President,,DEM,Elizabeth Warren,401
@@ -6376,30 +6376,30 @@ Hillsborough,Manchester Ward 7,President,,DEM,Wells,2
 Hillsborough,Manchester Ward 8,President,,DEM,Wells,0
 Hillsborough,Manchester Ward 9,President,,DEM,Wells,0
 Hillsborough,Manchester Ward 10,President,,DEM,Wells,2
-Hillsborough,Manchester Ward 11,President,,DEM,Wells,-
+Hillsborough,Manchester Ward 11,President,,DEM,Wells,
 Hillsborough,Manchester Ward 12,President,,DEM,Wells,1
-Hillsborough,Mason,President,,DEM,Wells,-
+Hillsborough,Mason,President,,DEM,Wells,
 Hillsborough,Merrimack,President,,DEM,Wells,2
-Hillsborough,Milford,President,,DEM,Wells,-
-Hillsborough,Mont Vernon,President,,DEM,Wells,-
+Hillsborough,Milford,President,,DEM,Wells,
+Hillsborough,Mont Vernon,President,,DEM,Wells,
 Hillsborough,Nashua -Ward 1,President,,DEM,Wells,1
-Hillsborough,Nashua -Ward 2,President,,DEM,Wells,-
-Hillsborough,Nashua- Ward 3,President,,DEM,Wells,-
-Hillsborough,Nashua -Ward 4,President,,DEM,Wells,-
-Hillsborough,Nashua -Ward 5,President,,DEM,Wells,-
+Hillsborough,Nashua -Ward 2,President,,DEM,Wells,
+Hillsborough,Nashua- Ward 3,President,,DEM,Wells,
+Hillsborough,Nashua -Ward 4,President,,DEM,Wells,
+Hillsborough,Nashua -Ward 5,President,,DEM,Wells,
 Hillsborough,Nashua -Ward 6,President,,DEM,Wells,1
-Hillsborough,Nashua -Ward 7,President,,DEM,Wells,-
+Hillsborough,Nashua -Ward 7,President,,DEM,Wells,
 Hillsborough,Nashua- Ward 8,President,,DEM,Wells,1
 Hillsborough,Nashua -Ward 9,President,,DEM,Wells,1
-Hillsborough,New Boston,President,,DEM,Wells,-
-Hillsborough,New Ipswich,President,,DEM,Wells,-
-Hillsborough,Pelham,President,,DEM,Wells,-
-Hillsborough,Peter-borough,President,,DEM,Wells,-
-Hillsborough,Sharon,President,,DEM,Wells,-
-Hillsborough,Temple,President,,DEM,Wells,-
-Hillsborough,Weare,President,,DEM,Wells,-
-Hillsborough,Wilton,President,,DEM,Wells,-
-Hillsborough,Windsor,President,,DEM,Wells,-
+Hillsborough,New Boston,President,,DEM,Wells,
+Hillsborough,New Ipswich,President,,DEM,Wells,
+Hillsborough,Pelham,President,,DEM,Wells,
+Hillsborough,Peter-borough,President,,DEM,Wells,
+Hillsborough,Sharon,President,,DEM,Wells,
+Hillsborough,Temple,President,,DEM,Wells,
+Hillsborough,Weare,President,,DEM,Wells,
+Hillsborough,Wilton,President,,DEM,Wells,
+Hillsborough,Windsor,President,,DEM,Wells,
 Hillsborough,Amherst,President,,DEM,Marianne Williamson,1
 Hillsborough,Antrim,President,,DEM,Marianne Williamson,0
 Hillsborough,Bedford,President,,DEM,Marianne Williamson,0
@@ -6426,30 +6426,30 @@ Hillsborough,Manchester Ward 7,President,,DEM,Marianne Williamson,0
 Hillsborough,Manchester Ward 8,President,,DEM,Marianne Williamson,0
 Hillsborough,Manchester Ward 9,President,,DEM,Marianne Williamson,0
 Hillsborough,Manchester Ward 10,President,,DEM,Marianne Williamson,1
-Hillsborough,Manchester Ward 11,President,,DEM,Marianne Williamson,-
+Hillsborough,Manchester Ward 11,President,,DEM,Marianne Williamson,
 Hillsborough,Manchester Ward 12,President,,DEM,Marianne Williamson,2
-Hillsborough,Mason,President,,DEM,Marianne Williamson,-
+Hillsborough,Mason,President,,DEM,Marianne Williamson,
 Hillsborough,Merrimack,President,,DEM,Marianne Williamson,1
 Hillsborough,Milford,President,,DEM,Marianne Williamson,3
-Hillsborough,Mont Vernon,President,,DEM,Marianne Williamson,-
+Hillsborough,Mont Vernon,President,,DEM,Marianne Williamson,
 Hillsborough,Nashua -Ward 1,President,,DEM,Marianne Williamson,1
 Hillsborough,Nashua -Ward 2,President,,DEM,Marianne Williamson,1
 Hillsborough,Nashua- Ward 3,President,,DEM,Marianne Williamson,1
-Hillsborough,Nashua -Ward 4,President,,DEM,Marianne Williamson,-
-Hillsborough,Nashua -Ward 5,President,,DEM,Marianne Williamson,-
-Hillsborough,Nashua -Ward 6,President,,DEM,Marianne Williamson,-
-Hillsborough,Nashua -Ward 7,President,,DEM,Marianne Williamson,-
+Hillsborough,Nashua -Ward 4,President,,DEM,Marianne Williamson,
+Hillsborough,Nashua -Ward 5,President,,DEM,Marianne Williamson,
+Hillsborough,Nashua -Ward 6,President,,DEM,Marianne Williamson,
+Hillsborough,Nashua -Ward 7,President,,DEM,Marianne Williamson,
 Hillsborough,Nashua- Ward 8,President,,DEM,Marianne Williamson,1
 Hillsborough,Nashua -Ward 9,President,,DEM,Marianne Williamson,2
-Hillsborough,New Boston,President,,DEM,Marianne Williamson,-
-Hillsborough,New Ipswich,President,,DEM,Marianne Williamson,-
+Hillsborough,New Boston,President,,DEM,Marianne Williamson,
+Hillsborough,New Ipswich,President,,DEM,Marianne Williamson,
 Hillsborough,Pelham,President,,DEM,Marianne Williamson,1
-Hillsborough,Peter-borough,President,,DEM,Marianne Williamson,-
-Hillsborough,Sharon,President,,DEM,Marianne Williamson,-
-Hillsborough,Temple,President,,DEM,Marianne Williamson,-
-Hillsborough,Weare,President,,DEM,Marianne Williamson,-
-Hillsborough,Wilton,President,,DEM,Marianne Williamson,-
-Hillsborough,Windsor,President,,DEM,Marianne Williamson,-
+Hillsborough,Peter-borough,President,,DEM,Marianne Williamson,
+Hillsborough,Sharon,President,,DEM,Marianne Williamson,
+Hillsborough,Temple,President,,DEM,Marianne Williamson,
+Hillsborough,Weare,President,,DEM,Marianne Williamson,
+Hillsborough,Wilton,President,,DEM,Marianne Williamson,
+Hillsborough,Windsor,President,,DEM,Marianne Williamson,
 Hillsborough,Amherst,President,,DEM,Andrew Yang,76
 Hillsborough,Antrim,President,,DEM,Andrew Yang,17
 Hillsborough,Bedford,President,,DEM,Andrew Yang,149

--- a/2020/20201103__nh__general__precinct.csv
+++ b/2020/20201103__nh__general__precinct.csv
@@ -6266,8 +6266,8 @@ Coos,Pinkham's Grant,State Senate,CS06,DEM,,1
 Coos,Shelburne,State Senate,CS06,DEM,,154
 Coos,COOS 06,State Senate,CS06,DEM,,1307
 Coos,Gorham,State Senate,CS06,,scatter,3
-Coos,Green's Grant,State Senate,CS06,,scatter,- ---
-Coos,Pinkham's Grant,State Senate,CS06,,scatter,- ---
+Coos,Green's Grant,State Senate,CS06,,scatter,
+Coos,Pinkham's Grant,State Senate,CS06,,scatter,
 Coos,Shelburne,State Senate,CS06,,scatter,5
 Coos,COOS 06,State Senate,CS06,,scatter,8
 Coos,Carroll,State House,CS07 (1)FL,REP,Troy Merner,282


### PR DESCRIPTION
This removes entries that consisted of only non-alphanumeric characters.

According to the data at

https://sos.nh.gov/elections/elections/election-results/,

these do not appear to be redactions for privacy concerns.  There is no note describing these symbols, and there are visible entries with just 1 or 2 votes.