### PR TITLE
Narrow bare excepts to Exception in the 2012 NH scrapers

### DIFF
--- a/2012/code/nh2012cd1.py
+++ b/2012/code/nh2012cd1.py
@@ -71,7 +71,7 @@ for sheet in sheets:
                 for col in range(1,ws.ncols):
                     candidate=[x for x in candidates if x in ws.cell(row,col).value][0]
                     cols_dict[col]=candidate
-        except:
+        except Exception:
             pass
         
 # Debug print statements

--- a/2012/code/nh2012cd2.py
+++ b/2012/code/nh2012cd2.py
@@ -75,7 +75,7 @@ for sheet in sheets:
                 for col in range(1,ws.ncols):
                     candidate=[x for x in candidates if x in ws.cell(row,col).value][0]
                     cols_dict[col]=candidate
-        except:
+        except Exception:
             pass
         
 # Debug print statements

--- a/2012/code/nh2012exec_council.py
+++ b/2012/code/nh2012exec_council.py
@@ -46,7 +46,7 @@ for sheet in sheets:
     ws = wb.sheet_by_name(sheet)
     try:
         district=re.search('[0-9]+',sheet).group(0)
-    except:
+    except Exception:
         district=''
     results_dict[district]=dict()
     candidate_dict=dict()
@@ -87,7 +87,7 @@ for sheet in sheets:
 #                            candidate_dict[candidate]['Party']='CON'
                         candidate_dict[candidate]['Party']=party_code.upper()
                     cols_dict[col]=candidate
-        except:
+        except Exception:
             pass    
         if(start_flag==2 and stop_flag==0):
             for offset in col_offset:

--- a/2012/code/nh2012gov.py
+++ b/2012/code/nh2012gov.py
@@ -74,7 +74,7 @@ for sheet in sheets:
                 for col in range(1,ws.ncols):
                     candidate=[x for x in candidates if x in ws.cell(row,col).value][0]
                     cols_dict[col]=candidate
-        except:
+        except Exception:
             pass
         
 # Debug print statements

--- a/2012/code/nh2012pres.py
+++ b/2012/code/nh2012pres.py
@@ -77,7 +77,7 @@ for sheet in sheets:
                 for col in range(1,ws.ncols):
                     candidate=[x for x in candidates if x in ws.cell(row,col).value][0]
                     cols_dict[col]=candidate
-        except:
+        except Exception:
             pass
         
 # Debug print statements

--- a/2012/code/nh2012state_rep.py
+++ b/2012/code/nh2012state_rep.py
@@ -140,7 +140,7 @@ for url in urls:
 #                            results_dict[district][town][candidate]=0
                         try:
                             results_dict[district][town][candidate]=int(value)
-                        except:
+                        except Exception:
                             results_dict[district][town][candidate]=0
                     prev_town=town
                 else:
@@ -149,7 +149,7 @@ for url in urls:
                 start_flag=2
             try:
                 row_test=str(ws.cell(row+1,0).value)=='' and start_flag==2                    
-            except:
+            except Exception:
                 row_test=False
             if('totals' in str(ws.cell(row,0).value).lower() or row_test):
                     # Clean up multiple wards into one set of results per town

--- a/2012/code/nh2012state_sen.py
+++ b/2012/code/nh2012state_sen.py
@@ -109,7 +109,7 @@ for url in urls:
                     print district
                     results_dict[district]=dict()
                     header_row=1
-            except:
+            except Exception:
                 pass
             if(start_flag==2 and stop_flag==0):
                 town=ws.cell(row,0).value


### PR DESCRIPTION
flake8 E722. Seven 2012 NH scrapers had `except: pass` blocks. Widen to `Exception` so KeyboardInterrupt doesn't get caught when re-running them.